### PR TITLE
Remove invalid leading 1 from zip code

### DIFF
--- a/exercises/phone-number/src/example/kotlin/PhoneNumber.kt
+++ b/exercises/phone-number/src/example/kotlin/PhoneNumber.kt
@@ -1,6 +1,6 @@
 data class PhoneNumber(private val rawNumber: String) {
     companion object {
-        private val validationRegex = Regex("^1?(\\d{10})$")
+        private val validationRegex = Regex("^1?([2-9]\\d{2}[2-9]\\d{6})$")
     }
     private val cleanedNumber = rawNumber.replace(Regex("[^\\d]"), "")
 

--- a/exercises/phone-number/src/test/kotlin/PhoneNumberTest.kt
+++ b/exercises/phone-number/src/test/kotlin/PhoneNumberTest.kt
@@ -8,8 +8,8 @@ class PhoneNumberTest {
 
     @Test
     fun cleansNumber() {
-        val expectedNumber = "1234567890"
-        val actualNumber = PhoneNumber("(123) 456-7890").number
+        val expectedNumber = "2234567890"
+        val actualNumber = PhoneNumber("(223) 456-7890").number
 
         assertEquals(expectedNumber, actualNumber)
     }
@@ -17,8 +17,8 @@ class PhoneNumberTest {
     @Ignore
     @Test
     fun cleansNumberWithDots() {
-        val expectedNumber = "1234567890"
-        val actualNumber = PhoneNumber("123.456.7890").number
+        val expectedNumber = "2234567890"
+        val actualNumber = PhoneNumber("223.456.7890").number
 
         assertEquals(expectedNumber, actualNumber)
     }
@@ -26,10 +26,18 @@ class PhoneNumberTest {
     @Ignore
     @Test
     fun validWhen11DigitsAndFirstIs1() {
-        val expectedNumber = "1234567890"
-        val actualNumber = PhoneNumber("11234567890").number
+        val expectedNumber = "2234567890"
+        val actualNumber = PhoneNumber("12234567890").number
 
         assertEquals(expectedNumber, actualNumber)
+    }
+
+    @Ignore
+    @Test(expected = IllegalArgumentException::class)
+    fun invalidWhen10DigitsAndFirstIs1() {
+        val actualNumber = PhoneNumber("1234567890")
+
+        fail("IllegalArgumentException should have been thrown")
     }
 
     @Ignore
@@ -43,7 +51,7 @@ class PhoneNumberTest {
     @Ignore
     @Test(expected = IllegalArgumentException::class)
     fun invalidWhen9Digits() {
-        val actualNumber = PhoneNumber("123456789")
+        val actualNumber = PhoneNumber("223456789")
 
         fail("IllegalArgumentException should have been thrown")
     }
@@ -51,8 +59,8 @@ class PhoneNumberTest {
     @Ignore
     @Test
     fun areaCode() {
-        val expectedAreaCode = "123"
-        val actualAreaCode = PhoneNumber("1234567890").areaCode
+        val expectedAreaCode = "223"
+        val actualAreaCode = PhoneNumber("2234567890").areaCode
 
         assertEquals(expectedAreaCode, actualAreaCode)
     }
@@ -60,8 +68,8 @@ class PhoneNumberTest {
     @Ignore
     @Test
     fun toStringPrint() {
-        val expectedtoStringNumber = "(123) 456-7890"
-        val actualtoStringNumber = PhoneNumber("1234567890").toString()
+        val expectedtoStringNumber = "(223) 456-7890"
+        val actualtoStringNumber = PhoneNumber("2234567890").toString()
 
         assertEquals(expectedtoStringNumber, actualtoStringNumber)
     }
@@ -69,8 +77,8 @@ class PhoneNumberTest {
     @Ignore
     @Test
     fun toStringPrintWithFullUSPhoneNumber() {
-        val expectedtoStringNumber = "(123) 456-7890"
-        val actualtoStringNumber = PhoneNumber("11234567890").toString()
+        val expectedtoStringNumber = "(223) 456-7890"
+        val actualtoStringNumber = PhoneNumber("12234567890").toString()
 
         assertEquals(expectedtoStringNumber, actualtoStringNumber)
     }


### PR DESCRIPTION
The README specifies that the first number of the area code must fall between 2 and 9. This updates the examples to lead with a `2` instead of a `1` for the area code, and adds an extra test verifying that the area code does not begin with a `1`.