### PR TITLE
Move script parity comment into scripts README

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,3 @@
+# Cross-track consistency
+
+Many of these scripts are shared between the Java and Kotlin tracks. If you make an update to a script in one of these tracks, please also update the same script in the other track if appropriate. Thank you!

--- a/bin/journey-test.sh
+++ b/bin/journey-test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# This script is shared between the Java and Kotlin tracks.  If you make an update to this script on
-# one track, please create a companion PR to merge it in to the other.  Thank you!
 TRACK=kotlin
 TRACK_REPO="$TRACK"
 TRACK_SRC_EXT="kt"


### PR DESCRIPTION
Hopefully this is higher-visibility; I've noticed unmatched changes occurring in the Java track :)