### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,103 +3,136 @@
   "language": "Kotlin",
   "repository": "https://github.com/exercism/kotlin",
   "active": true,
-  "deprecated": [
-    "accumulate",
-    "binary",
-    "hexadecimal",
-    "strain"
-  ],
   "foregone": [
 
   ],
   "exercises": [
     {
-      "difficulty": 1,
+      "uuid": "58c16459-348a-4536-8228-43379174735e",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 2,
+      "uuid": "9772c916-c619-445c-834d-af7dbf1ad2d9",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "0e9ca09d-c32e-4fed-930f-1b7c10b67dc2",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "7151ff23-ebc6-43d7-86b6-81cf0dd45309",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "1eb4c9d3-0085-4ca3-b1bb-9a20b88a1e7f",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "a91ce7e9-9a2a-44de-b10c-cc1be63df2a1",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "d8288e46-2e8c-42e4-8e14-20b1efd0f574",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "4d8a68eb-eee9-4c51-97b8-57f3b69f5970",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "93ee76ba-d19f-4c72-b011-676f40dcda5e",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "d54a68fc-02dd-45ee-8c6f-3efb781ed0d2",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "feee3ee9-81d5-4a4f-ad98-e1ecf21757ed",
       "slug": "secret-handshake",
-      "topics": [
-
-      ]
-    },
-    {
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
-      "slug": "perfect-numbers",
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "ad7c8fd8-acf0-40d0-8a30-d959c4b0252a",
+      "slug": "perfect-numbers",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+
+      ]
+    },
+    {
+      "uuid": "d3f960e5-cf19-4308-a1bc-897777f62689",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
         "Ranges",
         "Collections",
@@ -107,288 +140,411 @@
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "3cf8a650-6a25-416e-a0af-036f41c11cca",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "e282536b-267f-490c-a453-758135051a54",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "aa11e242-77b9-4ba7-97a2-d9b36e454a9d",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "1fa1e0f9-6410-4197-8778-debeb274e6d4",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "87ca4323-8a19-4529-962d-0f2ee63ebb2f",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "ab52d0f4-a001-4d44-951e-0cfc396374f3",
       "slug": "collatz-conjecture",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "b325401a-c8f0-49da-9f1a-a83318e780c9",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "6e2bbe8d-b6ab-4675-9c31-5b437cefd0c4",
       "slug": "nth-prime",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "371901d4-0728-4abd-8374-1905d7d70329",
       "slug": "saddle-points",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 4,
+      "uuid": "03c71e34-ecaf-47a4-9854-48600e1bf0d4",
       "slug": "diamond",
-      "topics": [
-
-      ]
-    },
-    {
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
+      "topics": [
+
+      ]
+    },
+    {
+      "uuid": "e5338be9-6f51-4448-9b10-20de7b1338b9",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "c67907b6-0d8b-4b12-9c41-6069845952a3",
       "slug": "flatten-array",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "cb2ce8e5-f143-4423-a3bc-959f4222c186",
       "slug": "pig-latin",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "2c8c1c16-bbb8-49e5-a248-f7a473c2bc86",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "62bd648a-e959-4ec4-8a5f-09e08fa0b2c8",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "3b8b77ef-da2d-499d-9513-8fe771e86b3e",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "e3407da5-0524-4565-b724-9778bba1033f",
       "slug": "spiral-matrix",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "ce475b23-5dfc-4049-90c5-0c387926686f",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "0e92ba19-2727-4a5e-be38-e88878322c53",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "a826af04-b7f3-426e-9bce-42375d0d928b",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "f3713067-7f37-4dd6-a189-c80f46dab8ec",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "67db30e4-b4d8-4224-b0f8-19a00af40387",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "cbbbd7db-224f-45ca-a108-4dc6bc98e4a0",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "9caa5fd9-a774-4d4c-951d-053a4f3f2726",
       "slug": "series",
-      "topics": [
-
-      ]
-    },
-    {
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
+      "topics": [
+
+      ]
+    },
+    {
+      "uuid": "7c24087a-ca61-48d3-9cb9-c3fde2edba86",
       "slug": "rotational-cipher",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 6,
+      "uuid": "da466ad5-6837-47d8-af39-2c0563d35a3c",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 6,
+      "uuid": "34f0e7d0-29df-44e5-a7a7-4a12584af62e",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 6,
+      "uuid": "f0f297f2-429f-4626-8b7f-0706a1e8f255",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 6,
+      "uuid": "fc977979-c8a4-44b6-a685-c8a32bd12bc3",
       "slug": "linked-list",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 6,
+      "uuid": "62eb71dd-18ba-427f-a27a-86e993b4055a",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 6,
+      "uuid": "6e3b294b-16a3-4ebb-a78b-4bf7f6b96736",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 6,
+      "uuid": "c8815b6c-19b8-4f4d-9be4-6717e933591a",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 6,
+      "uuid": "8eb6f225-fa3d-4a33-b476-2cae45053c82",
       "slug": "minesweeper",
-      "topics": [
-
-      ]
-    },
-    {
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
+      "topics": [
+
+      ]
+    },
+    {
+      "uuid": "19d00436-f26a-47ad-b13e-128181dc09f3",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 7,
+      "uuid": "f754e1cc-cb88-4776-ab11-3e6ae8362d5a",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 7,
+      "uuid": "ebfdf40a-1fde-4c88-aa93-95e3190f5261",
       "slug": "sublist",
-      "topics": [
-
-      ]
-    },
-    {
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
+      "topics": [
+
+      ]
+    },
+    {
+      "uuid": "1dcefdea-5447-4622-a064-079aad781398",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 8,
+      "uuid": "e23b06de-bd91-482f-9783-b0334b75b489",
       "slug": "simple-cipher",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 8,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 8,
+      "uuid": "83dec96f-9cdf-4b9b-abc4-cbd2066d919a",
       "slug": "complex-numbers",
-      "topics": [
-
-      ]
-    },
-    {
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
-      "slug": "change",
       "topics": [
 
       ]
     },
     {
-      "difficulty": 10,
+      "uuid": "0d69c1cd-f190-4b3b-8472-bf78c02acbc5",
+      "slug": "change",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 8,
+      "topics": [
+
+      ]
+    },
+    {
+      "uuid": "240788cd-afa5-4fd6-8df0-a158239c0610",
       "slug": "react",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 10,
       "topics": [
         "Reactive programming",
         "Generics",
@@ -397,25 +553,54 @@
       ]
     },
     {
-      "difficulty": 1,
+      "uuid": "639e59b6-84aa-4f13-9718-537606703c43",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 1,
+      "uuid": "34f1d5bf-f31f-415e-9905-4d48e6205d28",
       "slug": "list-ops",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 1,
+      "uuid": "12e1d685-32be-4b2c-a40b-c68e5b60de1d",
       "slug": "bank-account",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
         "Concurrency"
       ]
+    },
+    {
+      "uuid": "86015770-603b-44cf-aedf-f2a7cf79c841",
+      "slug": "accumulate",
+      "deprecated": true
+    },
+    {
+      "uuid": "def44955-c048-4b74-8777-2fb7d779b09e",
+      "slug": "binary",
+      "deprecated": true
+    },
+    {
+      "uuid": "13b1a62e-8e0e-4d57-b8c9-341b41f25cf5",
+      "slug": "hexadecimal",
+      "deprecated": true
+    },
+    {
+      "uuid": "8ae8492d-620c-4446-9928-5b4d78d496d9",
+      "slug": "strain",
+      "deprecated": true
     }
   ]
 }


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16