### PR TITLE
Double indent code blocks to allow numbered lists to not break

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -24,25 +24,25 @@ Open an administrative command prompt.  (If you need assistance opening an admin
 
 1. If you have not installed Chocolatey, do so now:
 
-       ```batchfile
-       C:\Windows\system32> @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
-       ```
+        ```batchfile
+        C:\Windows\system32> @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
+        ```
 
 2.  Install the JDK:
 
-       ```batchfile
-       C:\Windows\system32> choco install jdk8
-       ...
-       C:\Windows\system32> refreshenv
-       ...
-       ```
+        ```batchfile
+        C:\Windows\system32> choco install jdk8
+        ...
+        C:\Windows\system32> refreshenv
+        ...
+        ```
 
 3.  Install Gradle:
 
-       ```batchfile
-       C:\Windows\system32>choco install gradle
-       ...
-       ```
+        ```batchfile
+        C:\Windows\system32>choco install gradle
+        ...
+        ```
 
 We recommend closing the administrative command prompt and opening a new command prompt -- you do not require administrator priviledges to practice Exercism exercises.
 
@@ -60,27 +60,27 @@ Below are instructions for install using the most common method - using Homebrew
 
 1. If you haven't installed [Homebrew](http://brew.sh), yet, do so now:
 
-       ```sh
-       $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-       ```
+        ```sh
+        $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        ```
 
 2. Tap the [Homebrew Cask](https://caskroom.github.io/) — this allows us to install pre-built binaries like the JDK.
 
-       ```
-       $ brew tap caskroom/cask
-       ```
+        ```
+        $ brew tap caskroom/cask
+        ```
 
 3.  Install the JDK:
 
-       ```
-       $ brew cask install java
-       ```
+        ```
+        $ brew cask install java
+        ```
 
 4.  Install Gradle:
 
-       ```
-       $ brew install gradle
-       ```
+        ```
+        $ brew install gradle
+        ```
 
 You now are ready to get started with the Kotlin track of Exercism!
 
@@ -103,22 +103,22 @@ If you are using Debian or its derivatives (like Ubuntu or Linux Mint), use APT:
 
 1. Install the JDK:
 
-       ```sh
-       $ sudo apt-get update
-       $ sudo apt-get install python-software-properties
-       $ sudo add-apt-repository ppa:webupd8team/java
-       $ sudo apt-get update
-       $ sudo apt-get install oracle-java8-installer
-       $ sudo apt install oracle-java8-set-default
-       ```
+        ```sh
+        $ sudo apt-get update
+        $ sudo apt-get install python-software-properties
+        $ sudo add-apt-repository ppa:webupd8team/java
+        $ sudo apt-get update
+        $ sudo apt-get install oracle-java8-installer
+        $ sudo apt install oracle-java8-set-default
+        ```
 
 2. Install Gradle:
 
-       ```sh
-       $ sudo add-apt-repository ppa:cwchien/gradle
-       $ sudo apt-get update
-       $ sudo apt-get install gradle
-       ```
+        ```sh
+        $ sudo add-apt-repository ppa:cwchien/gradle
+        $ sudo apt-get update
+        $ sudo apt-get install gradle
+        ```
 
 You now are ready to get started with the Kotlin track of Exercism!
 
@@ -134,15 +134,15 @@ If you are using Fedora or its derivatives, use DNF:
 
 1. Install the JDK:
 
-       ```sh
-       $ sudo dnf install java-1.8.0-openjdk-devel
-       ```
+        ```sh
+        $ sudo dnf install java-1.8.0-openjdk-devel
+        ```
 
 2. Install Gradle:
 
-       ```sh
-       $ sudo dnf install gradle
-       ```
+        ```sh
+        $ sudo dnf install gradle
+        ```
 
 
 You now are ready to get started with the Kotlin track of Exercism!
@@ -190,21 +190,21 @@ To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tes
    1. Download "**Binary only distribution**" from the [Gradle download page](https://gradle.org/gradle-download/).
    2. Unpack Gradle:
 
-          ```sh
-          $ mkdir ~/tools
-          $ cd ~/tools
-          $ unzip ~/Downloads/gradle-*-bin.zip
-          $ cd gradle*
-          ```
+        ```sh
+        $ mkdir ~/tools
+        $ cd ~/tools
+        $ unzip ~/Downloads/gradle-*-bin.zip
+        $ cd gradle*
+        ```
 
    3. Configure Gradle and add it to the path:
 
-          ```sh
-          $ cat << DONE >> ~/.bashrc
-          export GRADLE_HOME=`pwd`
-          export PATH=\$PATH:\$GRADLE_HOME/bin
-          DONE
-          ```
+        ```sh
+        $ cat << DONE >> ~/.bashrc
+        export GRADLE_HOME=`pwd`
+        export PATH=\$PATH:\$GRADLE_HOME/bin
+        DONE
+        ```
 
 
 You now are ready to get started with the Kotlin track of Exercism!
@@ -224,21 +224,21 @@ To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tes
    1. Download "**Binary only distribution**" from the [Gradle download page](https://gradle.org/gradle-download/).
    2. Unpack Gradle:
 
-          ```sh
-          $ mkdir ~/tools
-          $ cd ~/tools
-          $ unzip ~/Downloads/gradle-*-bin.zip
-          $ cd gradle*
-          ```
+        ```sh
+        $ mkdir ~/tools
+        $ cd ~/tools
+        $ unzip ~/Downloads/gradle-*-bin.zip
+        $ cd gradle*
+        ```
 
    3. Configure Gradle and add it to the path:
 
-          ```sh
-          $ cat << DONE >> ~/.bashrc
-          export GRADLE_HOME=`pwd`
-          export PATH=\$PATH:\$GRADLE_HOME/bin
-          DONE
-          ```
+        ```sh
+        $ cat << DONE >> ~/.bashrc
+        export GRADLE_HOME=`pwd`
+        export PATH=\$PATH:\$GRADLE_HOME/bin
+        DONE
+        ```
 
 You now are ready to get started with the Kotlin track of Exercism!
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -24,23 +24,25 @@ Open an administrative command prompt.  (If you need assistance opening an admin
 
 1. If you have not installed Chocolatey, do so now:
 
-   ```batchfile
-   C:\Windows\system32> @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
-   ```
+       ```batchfile
+       C:\Windows\system32> @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
+       ```
+
 2.  Install the JDK:
 
-   ```batchfile
-   C:\Windows\system32> choco install jdk8
-   ...
-   C:\Windows\system32> refreshenv
-   ...
-   ```
+       ```batchfile
+       C:\Windows\system32> choco install jdk8
+       ...
+       C:\Windows\system32> refreshenv
+       ...
+       ```
+
 3.  Install Gradle:
 
-   ```batchfile
-   C:\Windows\system32>choco install gradle
-   ...
-   ```
+       ```batchfile
+       C:\Windows\system32>choco install gradle
+       ...
+       ```
 
 We recommend closing the administrative command prompt and opening a new command prompt -- you do not require administrator priviledges to practice Exercism exercises.
 
@@ -58,24 +60,27 @@ Below are instructions for install using the most common method - using Homebrew
 
 1. If you haven't installed [Homebrew](http://brew.sh), yet, do so now:
 
-   ```sh
-   $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-   ```
+       ```sh
+       $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+       ```
+
 2. Tap the [Homebrew Cask](https://caskroom.github.io/) — this allows us to install pre-built binaries like the JDK.
 
-   ```
-   $ brew tap caskroom/cask
-   ```
+       ```
+       $ brew tap caskroom/cask
+       ```
+
 3.  Install the JDK:
 
-   ```
-   $ brew cask install java
-   ```
+       ```
+       $ brew cask install java
+       ```
+
 4.  Install Gradle:
 
-   ```
-   $ brew install gradle
-   ```
+       ```
+       $ brew install gradle
+       ```
 
 You now are ready to get started with the Kotlin track of Exercism!
 
@@ -98,21 +103,22 @@ If you are using Debian or its derivatives (like Ubuntu or Linux Mint), use APT:
 
 1. Install the JDK:
 
-   ```sh
-   $ sudo apt-get update
-   $ sudo apt-get install python-software-properties
-   $ sudo add-apt-repository ppa:webupd8team/java
-   $ sudo apt-get update
-   $ sudo apt-get install oracle-java8-installer
-   $ sudo apt install oracle-java8-set-default
-   ```
+       ```sh
+       $ sudo apt-get update
+       $ sudo apt-get install python-software-properties
+       $ sudo add-apt-repository ppa:webupd8team/java
+       $ sudo apt-get update
+       $ sudo apt-get install oracle-java8-installer
+       $ sudo apt install oracle-java8-set-default
+       ```
+
 2. Install Gradle:
 
-   ```sh
-   $ sudo add-apt-repository ppa:cwchien/gradle
-   $ sudo apt-get update
-   $ sudo apt-get install gradle
-   ```
+       ```sh
+       $ sudo add-apt-repository ppa:cwchien/gradle
+       $ sudo apt-get update
+       $ sudo apt-get install gradle
+       ```
 
 You now are ready to get started with the Kotlin track of Exercism!
 
@@ -128,14 +134,15 @@ If you are using Fedora or its derivatives, use DNF:
 
 1. Install the JDK:
 
-   ```sh
-   $ sudo dnf install java-1.8.0-openjdk-devel
-   ```
+       ```sh
+       $ sudo dnf install java-1.8.0-openjdk-devel
+       ```
+
 2. Install Gradle:
 
-   ```sh
-   $ sudo dnf install gradle
-   ```
+       ```sh
+       $ sudo dnf install gradle
+       ```
 
 
 You now are ready to get started with the Kotlin track of Exercism!
@@ -183,20 +190,21 @@ To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tes
    1. Download "**Binary only distribution**" from the [Gradle download page](https://gradle.org/gradle-download/).
    2. Unpack Gradle:
 
-      ```sh
-      $ mkdir ~/tools
-      $ cd ~/tools
-      $ unzip ~/Downloads/gradle-*-bin.zip
-      $ cd gradle*
-      ```
+          ```sh
+          $ mkdir ~/tools
+          $ cd ~/tools
+          $ unzip ~/Downloads/gradle-*-bin.zip
+          $ cd gradle*
+          ```
+
    3. Configure Gradle and add it to the path:
 
-      ```sh
-      $ cat << DONE >> ~/.bashrc
-      export GRADLE_HOME=`pwd`
-      export PATH=\$PATH:\$GRADLE_HOME/bin
-     DONE
-     ```
+          ```sh
+          $ cat << DONE >> ~/.bashrc
+          export GRADLE_HOME=`pwd`
+          export PATH=\$PATH:\$GRADLE_HOME/bin
+          DONE
+          ```
 
 
 You now are ready to get started with the Kotlin track of Exercism!
@@ -216,20 +224,21 @@ To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tes
    1. Download "**Binary only distribution**" from the [Gradle download page](https://gradle.org/gradle-download/).
    2. Unpack Gradle:
 
-      ```sh
-      $ mkdir ~/tools
-      $ cd ~/tools
-      $ unzip ~/Downloads/gradle-*-bin.zip
-      $ cd gradle*
-      ```
+          ```sh
+          $ mkdir ~/tools
+          $ cd ~/tools
+          $ unzip ~/Downloads/gradle-*-bin.zip
+          $ cd gradle*
+          ```
+
    3. Configure Gradle and add it to the path:
 
-      ```sh
-      $ cat << DONE >> ~/.bashrc
-      export GRADLE_HOME=`pwd`
-      export PATH=\$PATH:\$GRADLE_HOME/bin
-     DONE
-     ```
+          ```sh
+          $ cat << DONE >> ~/.bashrc
+          export GRADLE_HOME=`pwd`
+          export PATH=\$PATH:\$GRADLE_HOME/bin
+          DONE
+          ```
 
 You now are ready to get started with the Kotlin track of Exercism!
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -24,25 +24,25 @@ Open an administrative command prompt.  (If you need assistance opening an admin
 
 1. If you have not installed Chocolatey, do so now:
 
-        ```batchfile
+      ```batchfile
         C:\Windows\system32> @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
-        ```
+      ```
 
 2.  Install the JDK:
 
-        ```batchfile
+       ```batchfile
         C:\Windows\system32> choco install jdk8
         ...
         C:\Windows\system32> refreshenv
         ...
-        ```
+       ```
 
 3.  Install Gradle:
 
-        ```batchfile
+       ```batchfile
         C:\Windows\system32>choco install gradle
         ...
-        ```
+       ```
 
 We recommend closing the administrative command prompt and opening a new command prompt -- you do not require administrator priviledges to practice Exercism exercises.
 
@@ -60,27 +60,27 @@ Below are instructions for install using the most common method - using Homebrew
 
 1. If you haven't installed [Homebrew](http://brew.sh), yet, do so now:
 
-        ```sh
+      ```sh
         $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-        ```
+      ```
 
 2. Tap the [Homebrew Cask](https://caskroom.github.io/) — this allows us to install pre-built binaries like the JDK.
 
-        ```
+      ```
         $ brew tap caskroom/cask
-        ```
+      ```
 
 3.  Install the JDK:
 
-        ```
+       ```
         $ brew cask install java
-        ```
+       ```
 
 4.  Install Gradle:
 
-        ```
+       ```
         $ brew install gradle
-        ```
+       ```
 
 You now are ready to get started with the Kotlin track of Exercism!
 
@@ -103,22 +103,22 @@ If you are using Debian or its derivatives (like Ubuntu or Linux Mint), use APT:
 
 1. Install the JDK:
 
-        ```sh
+      ```sh
         $ sudo apt-get update
         $ sudo apt-get install python-software-properties
         $ sudo add-apt-repository ppa:webupd8team/java
         $ sudo apt-get update
         $ sudo apt-get install oracle-java8-installer
         $ sudo apt install oracle-java8-set-default
-        ```
+      ```
 
 2. Install Gradle:
 
-        ```sh
+      ```sh
         $ sudo add-apt-repository ppa:cwchien/gradle
         $ sudo apt-get update
         $ sudo apt-get install gradle
-        ```
+      ```
 
 You now are ready to get started with the Kotlin track of Exercism!
 
@@ -134,15 +134,15 @@ If you are using Fedora or its derivatives, use DNF:
 
 1. Install the JDK:
 
-        ```sh
+      ```sh
         $ sudo dnf install java-1.8.0-openjdk-devel
-        ```
+      ```
 
 2. Install Gradle:
 
-        ```sh
+      ```sh
         $ sudo dnf install gradle
-        ```
+      ```
 
 
 You now are ready to get started with the Kotlin track of Exercism!
@@ -190,21 +190,21 @@ To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tes
    1. Download "**Binary only distribution**" from the [Gradle download page](https://gradle.org/gradle-download/).
    2. Unpack Gradle:
 
-        ```sh
+       ```sh
         $ mkdir ~/tools
         $ cd ~/tools
         $ unzip ~/Downloads/gradle-*-bin.zip
         $ cd gradle*
-        ```
+       ```
 
    3. Configure Gradle and add it to the path:
 
-        ```sh
+       ```sh
         $ cat << DONE >> ~/.bashrc
         export GRADLE_HOME=`pwd`
         export PATH=\$PATH:\$GRADLE_HOME/bin
         DONE
-        ```
+       ```
 
 
 You now are ready to get started with the Kotlin track of Exercism!
@@ -224,21 +224,21 @@ To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tes
    1. Download "**Binary only distribution**" from the [Gradle download page](https://gradle.org/gradle-download/).
    2. Unpack Gradle:
 
-        ```sh
+       ```sh
         $ mkdir ~/tools
         $ cd ~/tools
         $ unzip ~/Downloads/gradle-*-bin.zip
         $ cd gradle*
-        ```
+       ```
 
    3. Configure Gradle and add it to the path:
 
-        ```sh
+       ```sh
         $ cat << DONE >> ~/.bashrc
         export GRADLE_HOME=`pwd`
         export PATH=\$PATH:\$GRADLE_HOME/bin
         DONE
-        ```
+       ```
 
 You now are ready to get started with the Kotlin track of Exercism!
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -13,29 +13,29 @@ Choose your operating system:
 1. Open a Command Prompt.
 2. Get the first exercise:
 
-      ```batchfile
-        C:\Users\JohnDoe>exercism fetch kotlin
+    ```batchfile
+    C:\Users\JohnDoe>exercism fetch kotlin
 
-        Not Submitted:     1 problem
-        Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
+    Not Submitted:     1 problem
+    Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
 
-        New:               1 problem
-        Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
+    New:               1 problem
+    Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
 
-        unchanged: 0, updated: 0, new: 1
-      ```
+    unchanged: 0, updated: 0, new: 1
+    ```
 
 3. Change directory into the exercism:
 
-      ```batchfile
-        C:\Users\JohnDoe>cd C:\Users\JohnDoe\exercism\kotlin\hello-world
-      ```
+    ```batchfile
+    C:\Users\JohnDoe>cd C:\Users\JohnDoe\exercism\kotlin\hello-world
+    ```
 
 4. Run the tests:
 
-      ```batchfile
-        C:\Users\JohnDoe>gradle test
-      ```
+    ```batchfile
+    C:\Users\JohnDoe>gradle test
+    ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
@@ -51,26 +51,26 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 1. In the terminal window, get the first exercise:
 
-       ```
-        $ exercism fetch kotlin
+    ```
+    $ exercism fetch kotlin
 
-        New:                 1 problem
-        Kotlin (Etl) /Users/johndoe/exercism/kotlin/hello-world
+    New:                 1 problem
+    Kotlin (Etl) /Users/johndoe/exercism/kotlin/hello-world
 
-        unchanged: 0, updated: 0, new: 1
-       ```
+    unchanged: 0, updated: 0, new: 1
+    ```
 
 2. Change directory into the exercise:
 
-       ```
-        $ cd /Users/johndoe/exercism/kotlin/hello-world
-       ```
+    ```
+    $ cd /Users/johndoe/exercism/kotlin/hello-world
+    ```
 
 3. Run the tests:
 
-      ```
-       $ gradle test
-     ```
+    ```
+    $ gradle test
+    ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
@@ -85,26 +85,26 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 1. In the terminal window, get the first exercise:
 
-       ```
-        $ exercism fetch kotlin
+    ```
+    $ exercism fetch kotlin
 
-        New:                 1 problem
-        Kotlin (Etl) /home/johndoe/exercism/kotlin/hello-world
+    New:                 1 problem
+    Kotlin (Etl) /home/johndoe/exercism/kotlin/hello-world
 
-        unchanged: 0, updated: 0, new: 1
-       ```
+    unchanged: 0, updated: 0, new: 1
+    ```
 
 2. Change directory into the exercise:
 
-       ```
-        $ cd /home/johndoe/exercism/kotlin/hello-world
-       ```
+    ```
+    $ cd /home/johndoe/exercism/kotlin/hello-world
+    ```
 
 3. Run the tests:
 
-       ```
-        $ gradle test
-       ```
+    ```
+    $ gradle test
+    ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -13,29 +13,29 @@ Choose your operating system:
 1. Open a Command Prompt.
 2. Get the first exercise:
 
-       ```batchfile
-       C:\Users\JohnDoe>exercism fetch kotlin
+        ```batchfile
+        C:\Users\JohnDoe>exercism fetch kotlin
 
-       Not Submitted:     1 problem
-       Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
+        Not Submitted:     1 problem
+        Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
 
-       New:               1 problem
-       Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
+        New:               1 problem
+        Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
 
-       unchanged: 0, updated: 0, new: 1
-       ```
+        unchanged: 0, updated: 0, new: 1
+        ```
 
 3. Change directory into the exercism:
 
-       ```batchfile
-       C:\Users\JohnDoe>cd C:\Users\JohnDoe\exercism\kotlin\hello-world
-       ```
+        ```batchfile
+        C:\Users\JohnDoe>cd C:\Users\JohnDoe\exercism\kotlin\hello-world
+        ```
 
 4. Run the tests:
 
-       ```batchfile
-       C:\Users\JohnDoe>gradle test
-       ```
+        ```batchfile
+        C:\Users\JohnDoe>gradle test
+        ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
@@ -51,26 +51,26 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 1. In the terminal window, get the first exercise:
 
-       ```
-       $ exercism fetch kotlin
+        ```
+        $ exercism fetch kotlin
 
-       New:                 1 problem
-       Kotlin (Etl) /Users/johndoe/exercism/kotlin/hello-world
+        New:                 1 problem
+        Kotlin (Etl) /Users/johndoe/exercism/kotlin/hello-world
 
-       unchanged: 0, updated: 0, new: 1
-       ```
+        unchanged: 0, updated: 0, new: 1
+        ```
 
 2. Change directory into the exercise:
 
-       ```
-       $ cd /Users/johndoe/exercism/kotlin/hello-world
-       ```
+        ```
+        $ cd /Users/johndoe/exercism/kotlin/hello-world
+        ```
 
 3. Run the tests:
 
-      ```
-      $ gradle test
-      ```
+       ```
+       $ gradle test
+       ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
@@ -85,26 +85,26 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 1. In the terminal window, get the first exercise:
 
-       ```
-       $ exercism fetch kotlin
+        ```
+        $ exercism fetch kotlin
 
-       New:                 1 problem
-       Kotlin (Etl) /home/johndoe/exercism/kotlin/hello-world
+        New:                 1 problem
+        Kotlin (Etl) /home/johndoe/exercism/kotlin/hello-world
 
-       unchanged: 0, updated: 0, new: 1
-       ```
+        unchanged: 0, updated: 0, new: 1
+        ```
 
 2. Change directory into the exercise:
 
-       ```
-       $ cd /home/johndoe/exercism/kotlin/hello-world
-       ```
+        ```
+        $ cd /home/johndoe/exercism/kotlin/hello-world
+        ```
 
 3. Run the tests:
 
-      ```
-      $ gradle test
-      ```
+        ```
+        $ gradle test
+        ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -13,7 +13,7 @@ Choose your operating system:
 1. Open a Command Prompt.
 2. Get the first exercise:
 
-        ```batchfile
+      ```batchfile
         C:\Users\JohnDoe>exercism fetch kotlin
 
         Not Submitted:     1 problem
@@ -23,19 +23,19 @@ Choose your operating system:
         Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
 
         unchanged: 0, updated: 0, new: 1
-        ```
+      ```
 
 3. Change directory into the exercism:
 
-        ```batchfile
+      ```batchfile
         C:\Users\JohnDoe>cd C:\Users\JohnDoe\exercism\kotlin\hello-world
-        ```
+      ```
 
 4. Run the tests:
 
-        ```batchfile
+      ```batchfile
         C:\Users\JohnDoe>gradle test
-        ```
+      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
@@ -51,26 +51,26 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 1. In the terminal window, get the first exercise:
 
-        ```
+       ```
         $ exercism fetch kotlin
 
         New:                 1 problem
         Kotlin (Etl) /Users/johndoe/exercism/kotlin/hello-world
 
         unchanged: 0, updated: 0, new: 1
-        ```
+       ```
 
 2. Change directory into the exercise:
 
-        ```
+       ```
         $ cd /Users/johndoe/exercism/kotlin/hello-world
-        ```
+       ```
 
 3. Run the tests:
 
-       ```
+      ```
        $ gradle test
-       ```
+     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
@@ -85,26 +85,26 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 1. In the terminal window, get the first exercise:
 
-        ```
+       ```
         $ exercism fetch kotlin
 
         New:                 1 problem
         Kotlin (Etl) /home/johndoe/exercism/kotlin/hello-world
 
         unchanged: 0, updated: 0, new: 1
-        ```
+       ```
 
 2. Change directory into the exercise:
 
-        ```
+       ```
         $ cd /home/johndoe/exercism/kotlin/hello-world
-        ```
+       ```
 
 3. Run the tests:
 
-        ```
+       ```
         $ gradle test
-        ```
+       ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -13,30 +13,31 @@ Choose your operating system:
 1. Open a Command Prompt.
 2. Get the first exercise:
 
-   ```batchfile
-   C:\Users\JohnDoe>exercism fetch kotlin
-   ﻿
-   Not Submitted:     1 problem
-   Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
+       ```batchfile
+       C:\Users\JohnDoe>exercism fetch kotlin
 
-   New:               1 problem
-   Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
+       Not Submitted:     1 problem
+       Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
 
-   unchanged: 0, updated: 0, new: 1
+       New:               1 problem
+       Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
 
-   ```
+       unchanged: 0, updated: 0, new: 1
+       ```
+
 3. Change directory into the exercism:
 
-   ```batchfile
-   C:\Users\JohnDoe>cd C:\Users\JohnDoe\exercism\kotlin\hello-world
-   ```
+       ```batchfile
+       C:\Users\JohnDoe>cd C:\Users\JohnDoe\exercism\kotlin\hello-world
+       ```
 
 4. Run the tests:
 
-   ```batchfile
-   C:\Users\JohnDoe>gradle test
-   ```
+       ```batchfile
+       C:\Users\JohnDoe>gradle test
+       ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
+
 5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
 
 
@@ -50,25 +51,26 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 1. In the terminal window, get the first exercise:
 
-   ```
-   $ exercism fetch kotlin
+       ```
+       $ exercism fetch kotlin
 
-   New:                 1 problem
-   Kotlin (Etl) /Users/johndoe/exercism/kotlin/hello-world
+       New:                 1 problem
+       Kotlin (Etl) /Users/johndoe/exercism/kotlin/hello-world
 
-   unchanged: 0, updated: 0, new: 1
-   ```
+       unchanged: 0, updated: 0, new: 1
+       ```
 
 2. Change directory into the exercise:
 
-   ```
-   $ cd /Users/johndoe/exercism/kotlin/hello-world
-   ```
+       ```
+       $ cd /Users/johndoe/exercism/kotlin/hello-world
+       ```
+
 3. Run the tests:
 
-   ```
-   $ gradle test
-   ```
+      ```
+      $ gradle test
+      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
@@ -83,26 +85,26 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 1. In the terminal window, get the first exercise:
 
-   ```
-   $ exercism fetch kotlin
+       ```
+       $ exercism fetch kotlin
 
-   New:                 1 problem
-   Kotlin (Etl) /home/johndoe/exercism/kotlin/hello-world
+       New:                 1 problem
+       Kotlin (Etl) /home/johndoe/exercism/kotlin/hello-world
 
-   unchanged: 0, updated: 0, new: 1
-   ```
+       unchanged: 0, updated: 0, new: 1
+       ```
 
 2. Change directory into the exercise:
 
-   ```
-   $ cd /home/johndoe/exercism/kotlin/hello-world
-   ```
+       ```
+       $ cd /home/johndoe/exercism/kotlin/hello-world
+       ```
 
 3. Run the tests:
 
-   ```
-   $ gradle test
-   ```
+      ```
+      $ gradle test
+      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
 4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).


### PR DESCRIPTION
[Markdown syntax](https://daringfireball.net/projects/markdown/syntax#list) states code blocks should be double indented in order for the numbering in the lists to continue.

Seeing as how the Kotlin Installation and Tests page had numbered lists that were broken. I opted to fix them. [The issue is discussed here for v2 of exercism](https://github.com/exercism/v2-feedback/issues/105). I am checking the v1 pages to see what are affected by this.

As you can see the current rendering of the Installation page has the numbering thrown off. This should fix that.

![kotlin-tests](https://user-images.githubusercontent.com/7527155/29998793-e33f9d2e-9001-11e7-9ca2-d80cd8ffce2a.png)



As an example, this is how it will render when formatted as done in this PR (minus no CSS):

![kotlin-example](https://user-images.githubusercontent.com/7527155/29998797-fe681414-9001-11e7-880f-ac8d603f61ca.png)
