### PR TITLE
Adds Signal type to empty ArrayList in tests

### DIFF
--- a/exercises/secret-handshake/src/test/kotlin/HandshakeCalculatorTest.kt
+++ b/exercises/secret-handshake/src/test/kotlin/HandshakeCalculatorTest.kt
@@ -3,7 +3,7 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 /*
- * version: 1.1.0
+ * version: 1.1.1
  */
 class HandshakeCalculatorTest {
 
@@ -66,7 +66,7 @@ class HandshakeCalculatorTest {
     @Test
     fun testReversingNoActionsYieldsNoActions() {
         assertEquals(
-            emptyList(),
+            emptyList<Signal>(),
             HandshakeCalculator.calculateHandshake(16))
     }
 
@@ -90,7 +90,7 @@ class HandshakeCalculatorTest {
     @Test
     fun testThatInput0YieldsNoActions() {
         assertEquals(
-            emptyList(),
+            emptyList<Signal>(),
             HandshakeCalculator.calculateHandshake(0))
     }
 
@@ -98,7 +98,7 @@ class HandshakeCalculatorTest {
     @Test
     fun testThatInputWithLower5BitsNotSetYieldsNoActions() {
         assertEquals(
-            emptyList(),
+            emptyList<Signal>(),
             HandshakeCalculator.calculateHandshake(32))
     }
 


### PR DESCRIPTION
I was just doing this exercise when I noticed that it failed to compile unless a `Signal` type annotation was added to the `emptyList()`

This PR adds that annotation. Hope it helps.