### PR TITLE
Fix invalid exercise UUID

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,7 +15,7 @@
       "slug": "two-fer",
       "topics": null,
       "unlocked_by": null,
-      "uuid": "fa4194c5-084d-f780-4db6-707ef7bcc30c00e9ee5"
+      "uuid": "40f85461-c256-4b96-8d5b-0509f42fab17"
     },
     {
       "core": false,


### PR DESCRIPTION
The previous version of `configlet uuid` was known to generate invalid UUIDs. The latest release of Configlet [v3.6.1](https://github.com/exercism/configlet/releases) fixes that issue for newly added exercises, but existing exercise UUIDs need to be updated manually.

This change pertains to exercism/configlet#99