### PR TITLE
docs/TESTS.md: fix broken link and formatting

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -37,7 +37,7 @@ Choose your operating system:
    C:\Users\JohnDoe>gradle test
    ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
-5. Solve the exercise.  Find and work through the `GETTING_STARTED.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).
+5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
 
 
 Good luck!  Have fun!
@@ -57,8 +57,8 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
    Kotlin (Etl) /Users/johndoe/exercism/kotlin/hello-world
 
    unchanged: 0, updated: 0, new: 1
+   ```
 
-  ```
 2. Change directory into the exercise:
 
    ```
@@ -66,11 +66,12 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
    ```
 3. Run the tests:
 
-  ```
-  $ gradle test
-  ```
+   ```
+   $ gradle test
+   ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
-4. Solve the exercise.  Find and work through the `GETTING_STARTED.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).
+
+4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md)).
 
 Good luck!  Have fun!
 
@@ -89,20 +90,22 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
    Kotlin (Etl) /home/johndoe/exercism/kotlin/hello-world
 
    unchanged: 0, updated: 0, new: 1
+   ```
 
-  ```
 2. Change directory into the exercise:
 
    ```
    $ cd /home/johndoe/exercism/kotlin/hello-world
    ```
+
 3. Run the tests:
 
-  ```
-  $ gradle test
-  ```
+   ```
+   $ gradle test
+   ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
-4. Solve the exercise.  Find and work through the `GETTING_STARTED.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).
+
+4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.mdhttps://github.com/exercism/kotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).
 
 Good luck!  Have fun!
 


### PR DESCRIPTION
I noticed another broken link, so I've pointed it to the right markdown file now. I also improved the general formatting of the current markdown in docs/TESTS.md.