### PR TITLE
config: add blurb describing Kotlin

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,7 @@
 {
+  "language": "Kotlin",
   "active": true,
+  "blurb": "Kotlin is a pragmatic programming language for JVM and Android that combines OO and functional features and is focused on interoperability, safety, clarity and tooling support.",
   "exercises": [
     {
       "core": false,


### PR DESCRIPTION
As part of #202, a blurb should be added to `config.json` that describes the language.