### PR TITLE
update Kotlin to 1.2.40

### DIFF
--- a/exercises/accumulate/build.gradle
+++ b/exercises/accumulate/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/acronym/build.gradle
+++ b/exercises/acronym/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/all-your-base/build.gradle
+++ b/exercises/all-your-base/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/allergies/build.gradle
+++ b/exercises/allergies/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/anagram/build.gradle
+++ b/exercises/anagram/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/atbash-cipher/build.gradle
+++ b/exercises/atbash-cipher/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/bank-account/build.gradle
+++ b/exercises/bank-account/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-    ext.kotlin_version = '1.2.0'
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+  ext.kotlin_version = '1.2.40'
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+  }
 }
 
 apply plugin: 'kotlin'
@@ -13,20 +13,20 @@ apply plugin: 'kotlin'
 kotlin.experimental.coroutines = 'enable'
 
 repositories {
-    mavenCentral()
-    jcenter()
+  mavenCentral()
+  jcenter()
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    testCompile 'junit:junit:4.12'
-    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-    testCompile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.13'
+  testCompile 'junit:junit:4.12'
+  testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+  testCompile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.13'
 }
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'full'
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/beer-song/build.gradle
+++ b/exercises/beer-song/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/binary-search/build.gradle
+++ b/exercises/binary-search/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }
@@ -19,7 +19,6 @@ dependencies {
 
   testCompile 'junit:junit:4.12'
   testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-
 }
 test {
   testLogging {

--- a/exercises/binary/build.gradle
+++ b/exercises/binary/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/bob/build.gradle
+++ b/exercises/bob/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/bracket-push/build.gradle
+++ b/exercises/bracket-push/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/change/build.gradle
+++ b/exercises/change/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }
@@ -20,7 +20,6 @@ dependencies {
   testCompile 'junit:junit:4.12'
   testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
   testCompile "org.assertj:assertj-core:2.4.1"
-
 }
 test {
   testLogging {

--- a/exercises/clock/build.gradle
+++ b/exercises/clock/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/collatz-conjecture/build.gradle
+++ b/exercises/collatz-conjecture/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/complex-numbers/build.gradle
+++ b/exercises/complex-numbers/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/diamond/build.gradle
+++ b/exercises/diamond/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/difference-of-squares/build.gradle
+++ b/exercises/difference-of-squares/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/etl/build.gradle
+++ b/exercises/etl/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/flatten-array/build.gradle
+++ b/exercises/flatten-array/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/forth/build.gradle
+++ b/exercises/forth/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/gigasecond/build.gradle
+++ b/exercises/gigasecond/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/grade-school/build.gradle
+++ b/exercises/grade-school/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/grains/build.gradle
+++ b/exercises/grains/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/hamming/build.gradle
+++ b/exercises/hamming/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/hello-world/build.gradle
+++ b/exercises/hello-world/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/hexadecimal/build.gradle
+++ b/exercises/hexadecimal/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/isogram/build.gradle
+++ b/exercises/isogram/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/largest-series-product/build.gradle
+++ b/exercises/largest-series-product/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/leap/build.gradle
+++ b/exercises/leap/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/linked-list/build.gradle
+++ b/exercises/linked-list/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/list-ops/build.gradle
+++ b/exercises/list-ops/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/luhn/build.gradle
+++ b/exercises/luhn/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/meetup/build.gradle
+++ b/exercises/meetup/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/minesweeper/build.gradle
+++ b/exercises/minesweeper/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/nth-prime/build.gradle
+++ b/exercises/nth-prime/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/nucleotide-count/build.gradle
+++ b/exercises/nucleotide-count/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/pangram/build.gradle
+++ b/exercises/pangram/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/pascals-triangle/build.gradle
+++ b/exercises/pascals-triangle/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/perfect-numbers/build.gradle
+++ b/exercises/perfect-numbers/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/phone-number/build.gradle
+++ b/exercises/phone-number/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/pig-latin/build.gradle
+++ b/exercises/pig-latin/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/prime-factors/build.gradle
+++ b/exercises/prime-factors/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/raindrops/build.gradle
+++ b/exercises/raindrops/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/react/build.gradle
+++ b/exercises/react/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/rna-transcription/build.gradle
+++ b/exercises/rna-transcription/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/robot-name/build.gradle
+++ b/exercises/robot-name/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/robot-simulator/build.gradle
+++ b/exercises/robot-simulator/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/roman-numerals/build.gradle
+++ b/exercises/roman-numerals/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/rotational-cipher/build.gradle
+++ b/exercises/rotational-cipher/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/saddle-points/build.gradle
+++ b/exercises/saddle-points/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/say/build.gradle
+++ b/exercises/say/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/scrabble-score/build.gradle
+++ b/exercises/scrabble-score/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/secret-handshake/build.gradle
+++ b/exercises/secret-handshake/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/series/build.gradle
+++ b/exercises/series/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/sieve/build.gradle
+++ b/exercises/sieve/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/simple-cipher/build.gradle
+++ b/exercises/simple-cipher/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/space-age/build.gradle
+++ b/exercises/space-age/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/spiral-matrix/build.gradle
+++ b/exercises/spiral-matrix/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/strain/build.gradle
+++ b/exercises/strain/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/sublist/build.gradle
+++ b/exercises/sublist/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/sum-of-multiples/build.gradle
+++ b/exercises/sum-of-multiples/build.gradle
@@ -1,29 +1,28 @@
 buildscript {
-    ext.kotlin_version = '1.2.0'
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+  ext.kotlin_version = '1.2.40'
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+  }
 }
 
 apply plugin: 'kotlin'
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    testCompile 'junit:junit:4.12'
-    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+  testCompile 'junit:junit:4.12'
+  testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }
-
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'full'
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/triangle/build.gradle
+++ b/exercises/triangle/build.gradle
@@ -1,29 +1,28 @@
 buildscript {
-    ext.kotlin_version = '1.2.0'
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+  ext.kotlin_version = '1.2.40'
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+  }
 }
 
 apply plugin: 'kotlin'
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    testCompile 'junit:junit:4.12'
-    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+  testCompile 'junit:junit:4.12'
+  testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }
-
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'full'
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/two-fer/build.gradle
+++ b/exercises/two-fer/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }

--- a/exercises/word-count/build.gradle
+++ b/exercises/word-count/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.0'
+  ext.kotlin_version = '1.2.40'
   repositories {
     mavenCentral()
   }


### PR DESCRIPTION
Update Kotlin to 1.2.40. Fixes #204.

This fixes the issue where [Kotlin does not work on Java 10 with our version of Gradle](https://medium.com/@napperley/kotlin-does-work-on-java-10-aacc4a4fc89d).

I was experiencing this locally.

It may be worth looking into updating Gradle too, but nextercism compliance first!