### PR TITLE
Added missing types to expectedNumbers initiated to null

### DIFF
--- a/exercises/phone-number/src/test/kotlin/PhoneNumberTest.kt
+++ b/exercises/phone-number/src/test/kotlin/PhoneNumberTest.kt
@@ -64,7 +64,7 @@ class PhoneNumberTest {
     @Ignore
     @Test
     fun invalidWhenMoreThan11Digits() {
-        val expectedNumber = null
+        val expectedNumber: String? = null
         val actualNumber = PhoneNumber("321234567890").number
 
         assertEquals(expectedNumber, actualNumber)
@@ -73,7 +73,7 @@ class PhoneNumberTest {
     @Ignore
     @Test
     fun invalidWithLetters() {
-        val expectedNumber = null
+        val expectedNumber: String? = null
         val actualNumber = PhoneNumber("123-abc-7890").number
 
         assertEquals(expectedNumber, actualNumber)
@@ -82,7 +82,7 @@ class PhoneNumberTest {
     @Ignore
     @Test
     fun invalidWithInvalidPunctuation() {
-        val expectedNumber = null
+        val expectedNumber: String? = null
         val actualNumber = PhoneNumber("123-@:!-7890").number
 
         assertEquals(expectedNumber, actualNumber)


### PR DESCRIPTION
I'm getting compilation errors in `PhoneNumberTest.kt` with this message: 

> Type inference failed. The value of the type parameter T should be mentioned in input types (argument types, receiver type or expected type). Try to specify it explicitly.

Apparently, `assertEquals()` is getting confused because it can't infer the type of null in those three methods. I've added the String? type where I got the problem.
