### PR TITLE
Unlock leap by gigasecond

### DIFF
--- a/config.json
+++ b/config.json
@@ -31,7 +31,7 @@
       "slug": "leap",
       "uuid": "639e59b6-84aa-4f13-9718-537606703c43",
       "core": false,
-      "unlocked_by": "hello-world",
+      "unlocked_by": "gigasecond",
       "difficulty": 2,
       "topics": [
         "control_flow_if_else_statements",


### PR DESCRIPTION
Hello,

as a Kotlin newbie (with mostly R & Python experience; no Java) I stumbled a lot over the very early demand for advanced concepts (like [custom accessor of a property](https://exercism.io/my/solutions/74ecab0faaae46598406791bbde81ece) in [`leap`](https://github.com/exercism/kotlin/commit/4a2979ba0ae2150c3ffe86200139dacb857feac4)).

Since [`gigasecond`](https://github.com/exercism/kotlin/commit/b93e1f5ff71bf30634812285624ff88f653d7a76) is the first core exercise whose tests prescribe that concept, how about letting it unlock `leap`? I haven't looked at the other unlocks by `hello-world`, but the same idea may apply there.