### PR TITLE
Add more linked-list tests

### DIFF
--- a/exercises/linked-list/src/test/kotlin/DequeTest.kt
+++ b/exercises/linked-list/src/test/kotlin/DequeTest.kt
@@ -11,13 +11,35 @@ class DequeTest {
         subject = Deque()
     }
 
+    @Test
+    fun emptyPop() {
+        assertEquals(null, subject.pop())
+    }
 
+    @Ignore
+    @Test
+    fun emptyShift() {
+        assertEquals(null, subject.shift())
+    }
+
+    @Ignore
     @Test
     fun pushPop() {
         subject.push(10)
         subject.push(20)
         assertEquals(20, subject.pop())
         assertEquals(10, subject.pop())
+        assertEquals(null, subject.pop())
+    }
+
+    @Ignore
+    @Test
+    fun pushPopEmptyShift() {
+        subject.push(10)
+        subject.push(20)
+        assertEquals(20, subject.pop())
+        assertEquals(10, subject.pop())
+        assertEquals(null, subject.shift())
     }
 
     @Ignore
@@ -27,6 +49,17 @@ class DequeTest {
         subject.push(20)
         assertEquals(10, subject.shift())
         assertEquals(20, subject.shift())
+        assertEquals(null, subject.shift())
+    }
+
+    @Ignore
+    @Test
+    fun pushShiftEmptyPop() {
+        subject.push(10)
+        subject.push(20)
+        assertEquals(10, subject.shift())
+        assertEquals(20, subject.shift())
+        assertEquals(null, subject.pop())
     }
 
     @Ignore
@@ -36,6 +69,17 @@ class DequeTest {
         subject.unshift(20)
         assertEquals(20, subject.shift())
         assertEquals(10, subject.shift())
+        assertEquals(null, subject.shift())
+    }
+
+    @Ignore
+    @Test
+    fun unshiftShiftEmptyPop() {
+        subject.unshift(10)
+        subject.unshift(20)
+        assertEquals(20, subject.shift())
+        assertEquals(10, subject.shift())
+        assertEquals(null, subject.pop())
     }
 
     @Ignore
@@ -45,6 +89,17 @@ class DequeTest {
         subject.unshift(20)
         assertEquals(10, subject.pop())
         assertEquals(20, subject.pop())
+        assertEquals(null, subject.pop())
+    }
+
+    @Ignore
+    @Test
+    fun unshiftPopEmptyShift() {
+        subject.unshift(10)
+        subject.unshift(20)
+        assertEquals(10, subject.pop())
+        assertEquals(20, subject.pop())
+        assertEquals(null, subject.shift())
     }
 
     @Ignore
@@ -62,5 +117,31 @@ class DequeTest {
         assertEquals(40, subject.shift())
         assertEquals(50, subject.pop())
         assertEquals(30, subject.shift())
+    }
+
+    @Ignore
+    @Test
+    fun shiftAndPop() {
+        subject.push(10)
+        subject.push(20)
+        subject.push(30)
+
+        assertEquals(10, subject.shift())
+        assertEquals(30, subject.pop())
+        assertEquals(20, subject.pop())
+        assertEquals(null, subject.pop())
+    }
+
+    @Ignore
+    @Test
+    fun popAndShift() {
+        subject.push(10)
+        subject.push(20)
+        subject.push(30)
+
+        assertEquals(30, subject.pop())
+        assertEquals(10, subject.shift())
+        assertEquals(20, subject.shift())
+        assertEquals(null, subject.shift())
     }
 }


### PR DESCRIPTION
I felt that the tests for the linked-list exercise could be a little more thorough. As it is, the behavior of an empty deque is not defined, and there is no checking of pop or shift under this condition.

I chose to have the deque return `null` in this case, but it would also be appropriate to have it throw an exception. If that seems more reasonable I can update the tests :)