### PR TITLE
Fix gradle-school exercise test

### DIFF
--- a/exercises/grade-school/src/test/kotlin/SchoolTest.kt
+++ b/exercises/grade-school/src/test/kotlin/SchoolTest.kt
@@ -75,7 +75,7 @@ class SchoolTest {
         school.add("Christopher", 4)
         school.add("Kyle", 3)
 
-        val expected = mapOf(6 to listOf("Kareem"), 4 to listOf("Christopher", "Jennifer"), 3 to listOf("Kyle"))
+        val expected = mapOf(3 to listOf("Kyle"), 4 to listOf("Jennifer", "Christopher"), 6 to listOf("Kareem"))
         val sortedClasses = school.sort()
         assertEquals(expected, sortedClasses)
         assertEquals(listOf(3, 4, 6), sortedClasses.keys.toList(), "Grades not sorted in ascending order")


### PR DESCRIPTION
The `expected` value is incorrect, causing the test to fail. This is also true with the reference implementation of the exercise.