### PR TITLE
Grade school exercise improvement

### DIFF
--- a/exercises/bank-account/src/test/kotlin/BankAccountTest.kt
+++ b/exercises/bank-account/src/test/kotlin/BankAccountTest.kt
@@ -31,7 +31,7 @@ class BankAccountTest {
         val account = BankAccount()
         account.close()
 
-        assertFailsWith(IllegalStateException::class, { account.balance })
+        assertFailsWith(IllegalStateException::class) { account.balance }
     }
 
     @Ignore
@@ -40,7 +40,7 @@ class BankAccountTest {
         val account = BankAccount()
         account.close()
 
-        assertFailsWith(IllegalStateException::class, { account.adjustBalance(1000) })
+        assertFailsWith(IllegalStateException::class) { account.adjustBalance(1000) }
     }
 
     @Ignore

--- a/exercises/grade-school/src/test/kotlin/SchoolTest.kt
+++ b/exercises/grade-school/src/test/kotlin/SchoolTest.kt
@@ -57,8 +57,8 @@ class SchoolTest {
         school.add("Bradley", 5)
         school.add("Jeff", 1)
 
-        val expected = mapOf(5 to listOf("Franklin", "Bradley"), 1 to listOf("Jeff"))
-        assertEquals(expected, school.db())
+        val expected = mapOf(5 to listOf("Franklin", "Bradley"))
+        assertEquals(expected, school.grade(5))
     }
 
     @Ignore

--- a/exercises/rail-fence-cipher/src/test/kotlin/RailFenceCipherTest.kt
+++ b/exercises/rail-fence-cipher/src/test/kotlin/RailFenceCipherTest.kt
@@ -6,7 +6,7 @@ class RailFenceCipherTest {
 
     @Test
     fun encodeWithTwoRails() {
-        val railFenceCipher = RailFenceCipher(2);
+        val railFenceCipher = RailFenceCipher(2)
         assertEquals(
                 "XXXXXXXXXOOOOOOOOO",
                 railFenceCipher.getEncryptedData("XOXOXOXOXOXOXOXOXO")
@@ -16,7 +16,7 @@ class RailFenceCipherTest {
     @Ignore
     @Test
     fun encodeWithThreeRails() {
-        val railFenceCipher = RailFenceCipher(3);
+        val railFenceCipher = RailFenceCipher(3)
         assertEquals(
                 "WECRLTEERDSOEEFEAOCAIVDEN",
                 railFenceCipher.getEncryptedData("WEAREDISCOVEREDFLEEATONCE")
@@ -26,7 +26,7 @@ class RailFenceCipherTest {
     @Ignore
     @Test
     fun encodeWithEndingInTheMiddle() {
-        val railFenceCipher = RailFenceCipher(4);
+        val railFenceCipher = RailFenceCipher(4)
         assertEquals(
                 "ESXIEECSR",
                 railFenceCipher.getEncryptedData("EXERCISES")
@@ -36,7 +36,7 @@ class RailFenceCipherTest {
     @Ignore
     @Test
     fun decodeWithThreeRails() {
-        val railFenceCipher = RailFenceCipher(3);
+        val railFenceCipher = RailFenceCipher(3)
         assertEquals(
                 "THEDEVILISINTHEDETAILS",
                 railFenceCipher.getDecryptedData("TEITELHDVLSNHDTISEIIEA")
@@ -46,7 +46,7 @@ class RailFenceCipherTest {
     @Ignore
     @Test
     fun decodeWithFiveRails() {
-        val railFenceCipher = RailFenceCipher(5);
+        val railFenceCipher = RailFenceCipher(5)
         assertEquals(
                 "EXERCISMISAWESOME",
                 railFenceCipher.getDecryptedData("EIEXMSMESAORIWSCE")
@@ -56,7 +56,7 @@ class RailFenceCipherTest {
     @Ignore
     @Test
     fun decodeWithSixRails() {
-        val railFenceCipher = RailFenceCipher(6);
+        val railFenceCipher = RailFenceCipher(6)
         assertEquals(
                 "112358132134558914423337761098715972584418167651094617711286",
                 railFenceCipher.getDecryptedData("133714114238148966225439541018335470986172518171757571896261")


### PR DESCRIPTION
The test case `getsStudentsInAGrade` was intended to test the return value of the `grade(grade:Int)` when there are multiple students in different grades.
However, this test case was checking for the whole school db, calling the `db()` method, instead of calling the `grade(grade:Int)` method.

I aligned the test `getsStudentsInAGrade` to call the intended method.