### PR TITLE
Fix java installation step for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: java
+dist: trusty
 jdk:
   - oraclejdk8
 env:


### PR DESCRIPTION
Guys, we have our Travis builds [failing](https://travis-ci.org/exercism/kotlin/jobs/594976037) on **Installing oraclejdk8** step

> Installing oraclejdk8
$ export JAVA_HOME=\~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ \~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2019-09-17
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
Your build has been stopped.

There are two possible fixes: 
 - use *trsted* storage to install the jvm from
 - use *openjdk8* instead, which is safe as we do not exploit seasoned enterprise libs here. 

The first one is tried here as the easiest one  (avoids documetnation issues and local installation issues). Let me know, if the second one is preferrable. 

