### PR TITLE
binary-search-tree: add test case

### DIFF
--- a/exercises/binary-search-tree/src/test/kotlin/BinarySearchTreeTest.kt
+++ b/exercises/binary-search-tree/src/test/kotlin/BinarySearchTreeTest.kt
@@ -124,4 +124,14 @@ class BinarySearchTreeTest {
         val actual = tree.asSortedList()
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun `big tree level order`() {
+        val tree = BinarySearchTree<Int>()
+        val expected = listOf(8, 4, 12, 2, 6, 10, 14, 1, 3, 5, 7, 9, 11, 13, 15)
+        val treeData = listOf(8, 4, 2, 6, 1, 3, 5, 7, 12, 14, 10, 9, 11, 13, 15)
+        treeData.forEach(tree::insert)
+        val actual = tree.asLevelOrderList()
+        assertEquals(expected, actual)
+    }
 }


### PR DESCRIPTION
I see that some of the existing solution have not implemented the level-order algorithm correctly, but the mistakes are not exposed because the existing test cases are not deep enough. This change creates a tree 4 levels deep, and tests the asLevelOrderList() result.

The reference implementation correctly generates the level-order list of this bigger tree.