### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -1,3 +1,5 @@
+# About
+
 ## Type inference
 
 Kotlin compiler can infer types for functions and variables in most of the cases. However, declaring function return types explicitly for **public API** is a good practice.

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Kotlin is a **statically typed** programming language developed by JetBrains. This means that the type of variables is defined at compile-time.
 
 ### Variables

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -2,7 +2,7 @@
 
 Kotlin is a **statically typed** programming language developed by JetBrains. This means that the type of variables is defined at compile-time.
 
-### Variables
+## Variables
 
 Similarly to other statically-typed programming languages, the type of each variable should be defined at compile time. You can avoid explicit type declarations where they can be inferred by the compiler from their context.
 
@@ -25,7 +25,7 @@ print(index)  // 100
 
 Semicolons in Kotlin are optional, except for a few special cases that will be covered later.
 
-### Functions
+## Functions
 
 Functions in Kotlin are defined with the `fun` keyword and are _first-class citizens_ (not related to OOP). It means that you can declare (so-called `top-level functions`) them right in files (e.g. in Java you can define methods only in classes, not in files):
 
@@ -74,7 +74,7 @@ ping("exercism.io")  // PING --> exercism.io
 ping()               // PING --> localhost
 ```
 
-### Comments
+## Comments
 
 Use `//` to define single-line comment:
 

--- a/concepts/booleans/about.md
+++ b/concepts/booleans/about.md
@@ -1,3 +1,5 @@
+# About
+
 Booleans in Kotlin are represented by the `Boolean` type, which values can be either `true` or `false`.
 
 Kotlin supports three built-in [boolean operators][reference]: `!` (negation aka NOT), `&&` (lazy conjunction aka AND), and `||` (lazy disjunction aka OR). The `&&` and `||` operators use _short-circuit evaluation_, which means that the right-hand side of the operator is only evaluated when needed.

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Booleans in Kotlin are represented by the `Boolean` type, which values can be either `true` or `false`.
 
 Kotlin supports three built-in [boolean operators][reference]: `!` (negation aka NOT), `&&` (lazy conjunction aka AND), and `||` (lazy disjunction aka OR). The `&&` and `||` operators use _short-circuit evaluation_, which means that the right-hand side of the operator is only evaluated when needed.

--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,3 +1,5 @@
+# exercise readme insert
+
 ## Setup
 
 Go through the setup instructions for Kotlin to install the necessary

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Kotlin was designed and developed by JetBrains, the company behind IntelliJ. 
 It is a language that runs on the JVM which can target versions 6+ (including the [Android platform](https://blog.jetbrains.com/kotlin/2017/05/kotlin-on-android-now-official/)).
 JetBrains wanted to use a statically typed language which can remove Java boilerplate code, provide modern functional paradigms, and had seamless two-way Java interoperability with their existing codebase. 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,4 @@
-## Recommended learning resources
+# Recommended learning resources
 
 * [Kotlin Tutorials](https://kotlinlang.org/docs/tutorials/)
 * [Kotlin Documentation](https://kotlinlang.org/docs/reference/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,4 +1,4 @@
-## Recommended resources
+# Recommended resources
 
 * [Kotlin Documentation](https://kotlinlang.org/docs/reference/)
 * [Kotlin Forums](https://discuss.kotlinlang.org/)

--- a/exercises/concept/annalyns-infiltration/.docs/hints.md
+++ b/exercises/concept/annalyns-infiltration/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - There are three [boolean operators][reference] to work with boolean values.

--- a/exercises/concept/annalyns-infiltration/.docs/instructions.md
+++ b/exercises/concept/annalyns-infiltration/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, you'll be implementing the quest logic for a new RPG game a friend is developing. The game's main character is Annalyn, a brave girl with a fierce and loyal pet dog. Unfortunately, disaster strikes, as her best friend was kidnapped while searching for berries in the forest. Annalyn will try to find and free her best friend, optionally taking her dog with her on this quest.
 
 After some time spent following her best friend's trail, she finds the camp in which her best friend is imprisoned. It turns out there are two kidnappers: a mighty knight and a cunning archer.

--- a/exercises/concept/annalyns-infiltration/.docs/introduction.md
+++ b/exercises/concept/annalyns-infiltration/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Booleans in Kotlin are represented by the `Boolean` type, which values can be either `true` or `false`.
 
 Kotlin supports three built-in [boolean operators][reference]: `!` (negation aka NOT), `&&` (lazy conjunction aka AND), and `||` (lazy disjunction aka OR). The `&&` and `||` operators use _short-circuit evaluation_, which means that the right-hand side of the operator is only evaluated when needed.

--- a/exercises/concept/annalyns-infiltration/.meta/design.md
+++ b/exercises/concept/annalyns-infiltration/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the `Boolean` type and its two values.

--- a/exercises/concept/basics/.docs/hints.md
+++ b/exercises/concept/basics/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - An [integer (`Int`) value][numbers] can be defined as one or more consecutive digits.

--- a/exercises/concept/basics/.docs/instructions.md
+++ b/exercises/concept/basics/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 The owner of your local pizza place has asked you to help her to calculate cooking times for different pizzas. In this exercise you're going to write few functions to calculate that.
 
 You have three tasks.

--- a/exercises/concept/basics/.docs/introduction.md
+++ b/exercises/concept/basics/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Kotlin is a **statically typed** programming language developed by JetBrains. This means that the type of variables is defined at compile-time.
 
 ### Variables

--- a/exercises/concept/basics/.docs/introduction.md
+++ b/exercises/concept/basics/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 Kotlin is a **statically typed** programming language developed by JetBrains. This means that the type of variables is defined at compile-time.
 
-### Variables
+## Variables
 
 Similarly to other statically-typed programming languages, the type of each variable should be defined at compile time. You can avoid explicit type declarations where they can be inferred by the compiler from their context.
 
@@ -25,7 +25,7 @@ print(index)  // 100
 
 Semicolons in Kotlin are optional, except for a few special cases that will be covered later.
 
-### Functions
+## Functions
 
 Functions in Kotlin are defined with the `fun` keyword and are _first-class citizens_ (not related to OOP). It means that you can declare (so-called `top-level functions`) them right in files (e.g. in Java you can define methods only in classes, not in files):
 
@@ -74,7 +74,7 @@ ping("exercism.io")  // PING --> exercism.io
 ping()               // PING --> localhost
 ```
 
-### Comments
+## Comments
 
 Use `//` to define single-line comment:
 

--- a/exercises/concept/basics/.meta/design.md
+++ b/exercises/concept/basics/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 This exercise should teach bare minimum to help students understand Kotlin programs.

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 Since this is your first Kotlin exercise, we've included a detailed TUTORIAL.md
 file that guides you through your solution. Check it out for tips and
 assistance!

--- a/exercises/practice/hello-world/TUTORIAL.md
+++ b/exercises/practice/hello-world/TUTORIAL.md
@@ -1,3 +1,5 @@
+# Tutorial
+
 NOTE: You can also view the HTML version of this file here:
 https://github.com/exercism/kotlin/blob/master/exercises/hello-world/TUTORIAL.md
 

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 The tests for this exercise require you to use extensions, a mechanism for adding new functionality to an existing class whose source you do not directly control without having to subclass it. To learn more about Kotlin's implementations of extensions, check out the [official documentation](https://kotlinlang.org/docs/reference/extensions.html#extensions).
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
