### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "91fa3615-3f2d-44fe-a060-93dac297583c",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Kotlin locally",
+      "blurb": "Learn how to install Kotlin locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "015670c8-aded-4ba5-9824-454e928b8d37",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Kotlin",
+      "blurb": "An overview of how to get started from scratch with Kotlin"
+    },
+    {
+      "uuid": "f2a23a48-b160-4925-98c6-8844ab63b931",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Kotlin track",
+      "blurb": "Learn how to test your Kotlin exercises on Exercism"
+    },
+    {
+      "uuid": "336b6d0a-43a1-44d4-b1ac-0320aed1baa7",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Kotlin resources",
+      "blurb": "A collection of useful resources to help you master Kotlin"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
