### PR TITLE
Update build.gradle.kts

### DIFF
--- a/_template/build.gradle.kts
+++ b/_template/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    compile(kotlin("stdlib"))
+    implementation(kotlin("stdlib"))
     
     testImplementation("junit:junit:4.12")
     testImplementation(kotlin("test-junit"))


### PR DESCRIPTION
Change default repository from jCenter to Maven Central.  Fix outdated `implementation` for Kotlin stdlib.