### PR TITLE
CustomSet: Fix erroneous unit test expected value in CustomSetTest

### DIFF
--- a/exercises/practice/custom-set/src/test/kotlin/CustomSetTest.kt
+++ b/exercises/practice/custom-set/src/test/kotlin/CustomSetTest.kt
@@ -280,7 +280,7 @@ class CustomSetTest {
     fun `union of non empty sets contains all unique elements`() {
         val set1 = CustomSet(1, 3)
         val set2 = CustomSet(2, 3)
-        val expected = CustomSet(3, 2, 1)
+        val expected = CustomSet(1, 2, 3)
         assertEquals(expected, set1 + set2)
     }
 }


### PR DESCRIPTION
```
 @Test
  fun `union of non empty sets contains all unique elements`() {
      val set1 = CustomSet(1, 3)
      val set2 = CustomSet(2, 3)
      val expected = CustomSet(3, 2, 1)
      assertEquals(expected, set1 + set2)
  }
```

I think that this unit test is erroneous. The `expected` val should instead be `CustomSet(1, 2, 3)`

All the other unit tests keep the `CustomSet` sorted ascending except this one.

Without keeping the underlying data structure sorted in some way, the exercise cannot be done.

I will open a PR to fix this if that's alright.