### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -858,7 +858,7 @@
       {
         "slug": "kindergarten-garden",
         "name": "Kindergarten Garden",
-        "uuid": "0b92ffee-c092-4ab1-ad78-76c8cf80e1b5",
+        "uuid": "1603e77a-0fbc-43ed-8200-b86a4219af8d",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -1131,7 +1131,7 @@
       {
         "slug": "diffie-hellman",
         "name": "Diffie Hellman",
-        "uuid": "9b191b2f-b1a4-4c0e-b911-36666bff614d",
+        "uuid": "33d64c7c-292e-4221-aed8-ac411a9d490d",
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,

--- a/config.json
+++ b/config.json
@@ -1250,7 +1250,7 @@
       {
         "slug": "reverse-string",
         "name": "Reverse String",
-        "uuid": "0000e75e-9b43-11e8-98d0-529269fb1459",
+        "uuid": "95d495a6-b1a2-42d5-8190-443d6f94e80b",
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
