### PR TITLE
🤖 Add stub files to all exercises

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -3,13 +3,13 @@
   "authors": [],
   "files": {
     "solution": [
-      "src/main/kotlin/ArmstrongNumbers.kt"
+      "src/main/kotlin/ArmstrongNumber.kt"
     ],
     "test": [
-      "src/test/kotlin/ArmstrongNumbersTest.kt"
+      "src/test/kotlin/ArmstrongNumberTest.kt"
     ],
     "example": [
-      ".meta/src/main/kotlin/ArmstrongNumbers.kt"
+      ".meta/src/main/kotlin/ArmstrongNumber.kt"
     ]
   },
   "source": "Wikipedia",

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -3,13 +3,13 @@
   "authors": [],
   "files": {
     "solution": [
-      "src/main/kotlin/ScaleGenerator.kt"
+      "src/main/kotlin/Scale.kt"
     ],
     "test": [
-      "src/test/kotlin/ScaleGeneratorTest.kt"
+      "src/test/kotlin/ScaleTest.kt"
     ],
     "example": [
-      ".meta/src/main/kotlin/ScaleGenerator.kt"
+      ".meta/src/main/kotlin/Scale.kt"
     ]
   }
 }


### PR DESCRIPTION
In this PR, we created (empty) stub files for all exercises that didn't yet have them.

The lack of stub file generates an unnecessary pain point within Exercism, contributing a significant proportion of support requests, making things more complex for our students, and hindering our ability to automatically run test-suites and provide automated analysis of solutions.

The original discussion for this is at exercism/discussions#238.

**We will automatically merge this PR in two week's time if it has not been merged by track maintainers at that point :slightly_smiling_face:**

## Tracking

https://github.com/exercism/v3-launch/issues/33
