### PR TITLE
Change linter command for CI

### DIFF
--- a/bin/unit-tests.sh
+++ b/bin/unit-tests.sh
@@ -9,7 +9,7 @@ rm -rf ./exercises/build
 echo ""
 echo ">>> Running configlet..."
 bin/fetch-configlet
-bin/configlet lint .
+bin/configlet lint
 
 pushd exercises
 echo ""


### PR DESCRIPTION
Seems like new configlet should be run as `configlet lint` but currently it's used as `configlet lint .`.

CI check will still fail but not because of Gradle. I'm checking it too (#471).