### PR TITLE
Luhn: A new test case with odd number of digits

### DIFF
--- a/exercises/practice/luhn/src/test/kotlin/LuhnTest.kt
+++ b/exercises/practice/luhn/src/test/kotlin/LuhnTest.kt
@@ -64,6 +64,10 @@ class LuhnTest {
     @Test
     fun `valid | input digit 9`() = assertValid("091")
 
+    @Ignore
+    @Test
+    fun `valid | odd amount of digits with non zero first digit`() = assertValid("109")
+
     /**
      * Convert non-digits to their ascii values and then offset them by 48
      * sometimes accidentally declare an invalid string to be valid.


### PR DESCRIPTION
A new positive test case with odd number of digits and non-zero first digit.
I have seen a solution in Golang which passes all the tests for Luhn containing odd number of digits and never reads the first digit.
It happens because in all such cases the first digit is zero . I am sure it is also relevant for Kotlin as well.