### PR TITLE
Make stub class match tests and example

### DIFF
--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -12,7 +12,7 @@
     "uzilan"
   ],
   "files": {
-    "solution": ["src/main/kotlin/RobotSimulator.kt"],
+    "solution": ["src/main/kotlin/Robot.kt"],
     "test": ["src/test/kotlin/RobotTest.kt"],
     "example": [".meta/src/reference/kotlin/Robot.kt"]
   },

--- a/exercises/practice/robot-simulator/src/main/kotlin/Robot.kt
+++ b/exercises/practice/robot-simulator/src/main/kotlin/Robot.kt
@@ -1,4 +1,4 @@
-class RobotSimulator {
+class Robot {
 
     // TODO: implement proper constructor, provide read access to `gridPosition` and `orientation`
 


### PR DESCRIPTION
* Tests expect `Robot` class, not `RobotSimulator`
* Same for example solution, it's `Robot.kt`, not `RobotSimulator.kt`