### PR TITLE
Remove internal keyword on exercise twofer

### DIFF
--- a/exercises/practice/two-fer/src/main/kotlin/TwoFer.kt
+++ b/exercises/practice/two-fer/src/main/kotlin/TwoFer.kt
@@ -1,3 +1,3 @@
-internal fun twofer(name: String): String {
+fun twofer(name: String): String {
     TODO("Implement the function to complete the task")
 }


### PR DESCRIPTION
Internal is not needed here and often confusing to newcomers.

---

![image](https://user-images.githubusercontent.com/43913051/160802582-21728a2c-8043-4588-8918-18f993ff133b.png)
