### PR TITLE
Replace deprecated dependency

### DIFF
--- a/exercises/practice/diamond/src/test/kotlin/DiamondPrinterTest.kt
+++ b/exercises/practice/diamond/src/test/kotlin/DiamondPrinterTest.kt
@@ -1,5 +1,5 @@
 import org.hamcrest.CoreMatchers.`is`
-import org.junit.Assert.assertThat
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test


### PR DESCRIPTION
`org.junit.Assert.assertThat` is deprecated and should be replaced by `org.hamcrest.MatcherAssert.assertThat`.