### PR TITLE
flatten-array: test for heterogeneous lists

### DIFF
--- a/exercises/practice/flatten-array/src/test/kotlin/FlattenerTest.kt
+++ b/exercises/practice/flatten-array/src/test/kotlin/FlattenerTest.kt
@@ -47,7 +47,7 @@ class FlattenerTest {
 
     @Ignore
     @Test
-    fun flattensHetrogenousList() {
+    fun flattensHeterogenousList() {
         val nestedList = listOf(0, 2.1, listOf(listOf(true, "flatten"), 'a', listOf(listOf(100)), null, listOf(listOf(null))), -2)
         assertEquals(listOf(0, 2.1, true, "flatten", 'a', 100, -2), Flattener.flatten(nestedList))
     }

--- a/exercises/practice/flatten-array/src/test/kotlin/FlattenerTest.kt
+++ b/exercises/practice/flatten-array/src/test/kotlin/FlattenerTest.kt
@@ -45,4 +45,10 @@ class FlattenerTest {
         assertEquals(emptyList<Any>(), Flattener.flatten(nestedList))
     }
 
+    @Ignore
+    @Test
+    fun flattensHetrogenousList() {
+        val nestedList = listOf(0, 2.1, listOf(listOf(true, "flatten"), 'a', listOf(listOf(100)), null, listOf(listOf(null))), -2)
+        assertEquals(listOf(0, 2.1, true, "flatten", 'a', 100, -2), Flattener.flatten(nestedList))
+    }
 }


### PR DESCRIPTION
Hi 👋 

This adds a test to the `flatten-array` problem that forces solutions to work on `Collection<Any?>`. At present they can get away with just `Collection<Int?>`.

Nothing too controvertial (I hope).

