### PR TITLE
Update readme - gradle test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To run the tests for a specific exercise, run the `test` Gradle task from the ex
 directory. For example:
 
 ```bash
-cd exercises
+cd exercises/practice
 https://github.com/exercism/v3/blob/main/gradlew bob:test
 
 ```


### PR DESCRIPTION
Updated the readme instructions for how to run tests against an exercise like `bob` as it wasn't clear that it was in the practice folder.