### PR TITLE
Update space-age: less strict on precision

### DIFF
--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -9,6 +9,7 @@
     "lihofm",
     "mdowds",
     "nithia",
+    "sanderploegsma",
     "sjwarner-bp",
     "SleeplessByte",
     "stkent",

--- a/exercises/practice/space-age/.meta/src/reference/kotlin/SpaceAge.kt
+++ b/exercises/practice/space-age/.meta/src/reference/kotlin/SpaceAge.kt
@@ -1,11 +1,7 @@
-import java.math.BigDecimal
-import java.math.RoundingMode
-
 class SpaceAge(private val seconds: Long) {
 
     companion object {
         const val EARTH_ORBITAL_PERIOD_IN_SECONDS = 31557600.0
-        const val PRECISION = 2
 
         private enum class Planet(val relativeOrbitalPeriod: Double) {
             EARTH(1.0),
@@ -28,9 +24,6 @@ class SpaceAge(private val seconds: Long) {
     fun onUranus() = calculateAge(Planet.URANUS)
     fun onNeptune() = calculateAge(Planet.NEPTUNE)
 
-    private fun calculateAge(planet: Planet): Double {
-        val age: Double = seconds / (EARTH_ORBITAL_PERIOD_IN_SECONDS * planet.relativeOrbitalPeriod)
-
-        return BigDecimal(age).setScale(PRECISION, RoundingMode.HALF_UP).toDouble()
-    }
+    private fun calculateAge(planet: Planet): Double = 
+        seconds / (EARTH_ORBITAL_PERIOD_IN_SECONDS * planet.relativeOrbitalPeriod)
 }

--- a/exercises/practice/space-age/src/test/kotlin/SpaceAgeTest.kt
+++ b/exercises/practice/space-age/src/test/kotlin/SpaceAgeTest.kt
@@ -35,4 +35,7 @@ class SpaceAgeTest {
     fun `age on Neptune`() = assertYearsEqual(0.35, SpaceAge(1821023456).onNeptune())
 }
 
-private fun assertYearsEqual(expectedYears: Double, actualYears: Double) = assertEquals(expectedYears, actualYears)
+private const val TOLERANCE = 0.01
+
+private fun assertYearsEqual(expectedYears: Double, actualYears: Double) = 
+    assertEquals(expectedYears, actualYears, absoluteTolerance = TOLERANCE)


### PR DESCRIPTION
The test suite of space-age was incorrectly forcing solutions to round their answers to two decimal places.

Even though the test data suggests using two decimal places, it should be the responsibility of the tests to be able to handle more precise answers. Having to use `BigDecimal` to round to two decimal places in the solution seems out-of-scope for this exercise.