### PR TITLE
Fix markdown link not displaying for secret handshake

### DIFF
--- a/exercises/practice/secret-handshake/.docs/instructions.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.md
@@ -41,7 +41,6 @@ The secret handshake for 26 is therefore:
 jump, double blink
 ```
 
-~~~~exercism/note
 If you aren't sure what binary is or how it works, check out [this binary tutorial][intro-to-binary].
+
 [intro-to-binary]: https://medium.com/basecs/bits-bytes-building-with-binary-13cb4289aafa
-~~~~


### PR DESCRIPTION
### Description
I removed the note wrapper which seems to break the markdown linker to replace the url properly for the "this binary tutorial"

### Bug
Illustration of the bug on exercism website
![image](https://github.com/valentin-p/kotlin/assets/3833193/a1633aae-7e5e-4f43-974e-3a30102bcc23)

Illustration of the bug on vs code md preview
![image](https://github.com/valentin-p/kotlin/assets/3833193/11fd6aa5-529f-41c8-a6de-109a33b12eb3)

### Resolved
The "fixed" version on github md preview
![image](https://github.com/valentin-p/kotlin/assets/3833193/72b20d78-0d4d-478a-b0fa-a094bb123ee4)
