### PR TITLE
Fix CI silently not running concept exercise tests

### DIFF
--- a/bin/journey-test.sh
+++ b/bin/journey-test.sh
@@ -160,7 +160,7 @@ main() {
 # Execution begins here...
 
 # If any command fails, fail the script.
-set -ex
+set -exo pipefail
 SCRIPTPATH=$( pushd `dirname $0` > /dev/null && pwd && popd > /dev/null )
 EXECPATH=$( pwd )
 # Make output easier to read in CI

--- a/bin/journey-test.sh
+++ b/bin/journey-test.sh
@@ -78,7 +78,7 @@ solve_all_exercises() {
     echo ">>> solve_all_exercises(exercism_exercises_dir=\"${exercism_exercises_dir}\")"
     
     local track_root=$( pwd )
-    local concept_exercises=`jq -r '.exercises.concept[].slug | sort' config.json | sort | xargs`
+    local concept_exercises=`jq -r '.exercises.concept[].slug' config.json | sort | xargs`
     local practice_exercises=`jq -r '.exercises.practice[].slug' config.json | sort | xargs`
     local total_exercises=`jq '.exercises.concept + .exercises.practice | length' config.json`
     local current_exercise_number=1


### PR DESCRIPTION
Similar to https://github.com/exercism/java/pull/2339, this fixes the `bin/journey-test.sh` script to test all exercises, where previously it skipped concept exercises due to an error in the jq query.

It also adds `set -o pipefail` to the script so that errors like these will no longer be silently ignored in the future.