### PR TITLE
fix: removed the @Ignore from the Tests

### DIFF
--- a/exercises/practice/acronym/src/test/kotlin/AcronymTest.kt
+++ b/exercises/practice/acronym/src/test/kotlin/AcronymTest.kt
@@ -8,49 +8,41 @@ class AcronymTest {
             "Portable Network Graphics",
             "PNG")
 
-    @Ignore
     @Test
     fun `lowercase word in the middle`() = assertAcronymEquals(
             "Ruby on Rails",
             "ROR")
 
-    @Ignore
     @Test
     fun `punctuation is ignored`() = assertAcronymEquals(
             "First In, First Out",
             "FIFO")
 
-    @Ignore
     @Test
     fun `uppercased word at the start`() = assertAcronymEquals(
             "GNU Image Manipulation Program",
             "GIMP")
 
-    @Ignore
     @Test
     fun `hyphen is ignored`() = assertAcronymEquals(
             "Complementary metal-oxide semiconductor",
             "CMOS")
 
-    @Ignore
     @Test
     fun `lots of words`() = assertAcronymEquals(
             "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me",
             "ROTFLSHTMDCOALM")
 
-    @Ignore
     @Test
     fun `consecutive delimiters`() = assertAcronymEquals(
             "Something - I made up from thin air",
             "SIMUFTA")
 
-    @Ignore
     @Test
     fun `apostrophe is ignored`() = assertAcronymEquals(
             "Halley's Comet",
             "HC")
 
-    @Ignore
     @Test
     fun `underscore emphasis is ignored`() = assertAcronymEquals(
             "The Road _Not_ Taken",


### PR DESCRIPTION
This pull request includes changes to the `AcronymTest` class in `exercises/practice/acronym/src/test/kotlin/AcronymTest.kt` to enable previously ignored tests. 
This allows exercism users to properly test their solution.