### PR TITLE
Update Yacht's config.json to include the second required solution source file

### DIFF
--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -8,7 +8,8 @@
   ],
   "files": {
     "solution": [
-      "src/main/kotlin/Yacht.kt"
+      "src/main/kotlin/Yacht.kt",
+      "src/main/kotlin/YachtCategory.kt"
     ],
     "test": [
       "src/test/kotlin/YachtTest.kt"

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -8,14 +8,16 @@
   ],
   "files": {
     "solution": [
-      "src/main/kotlin/Yacht.kt",
-      "src/main/kotlin/YachtCategory.kt"
+      "src/main/kotlin/Yacht.kt"
     ],
     "test": [
       "src/test/kotlin/YachtTest.kt"
     ],
     "example": [
       ".meta/src/reference/kotlin/Yacht.kt"
+    ],
+    "editor": [
+      "src/main/kotlin/YachtCategory.kt"
     ]
   },
   "blurb": "Score a single throw of dice in the game Yacht.",


### PR DESCRIPTION
The exercise relies on the `Yacht.kt` file and this one depends on `YachtCategory.kt` file (which declares the utility enum class).

As of now, only `Yacht.kt` is included in the solution files array inside config.json.
This causes the two following errors :
- HELP.md is not mentioning the correct command to submit the exercise (beginners using the Exercism CLI may not easily understand why tests are passing locally but not on the server) : `exercism submit src/main/kotlin/Yacht.kt` (currently) instead of `exercism submit src/main/kotlin/Yacht.kt src/main/kotlin/YachtCategory.kt` (corrected)
- The shortcut command (`exercism submit` without any arguments) uses only Yacht.kt instead of passing both files

With the addition of `YachtCategory.kt` in the solution files, these two issues are fixed.