### PR TITLE
Regenerate tests.toml files

### DIFF
--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,28 +1,37 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# basic
-"1e22cceb-c5e4-4562-9afe-aef07ad1eaf4" = true
+[1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
+description = "basic"
 
-# lowercase words
-"79ae3889-a5c0-4b01-baf0-232d31180c08" = true
+[79ae3889-a5c0-4b01-baf0-232d31180c08]
+description = "lowercase words"
 
-# punctuation
-"ec7000a7-3931-4a17-890e-33ca2073a548" = true
+[ec7000a7-3931-4a17-890e-33ca2073a548]
+description = "punctuation"
 
-# all caps word
-"32dd261c-0c92-469a-9c5c-b192e94a63b0" = true
+[32dd261c-0c92-469a-9c5c-b192e94a63b0]
+description = "all caps word"
 
-# punctuation without whitespace
-"ae2ac9fa-a606-4d05-8244-3bcc4659c1d4" = true
+[ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
+description = "punctuation without whitespace"
 
-# very long abbreviation
-"0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9" = true
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
 
-# consecutive delimiters
-"6a078f49-c68d-4b7b-89af-33a1a98c28cc" = true
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
 
-# apostrophes
-"5118b4b1-4572-434c-8d57-5b762e57973e" = true
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
 
-# underscore emphasis
-"adc12eab-ec2d-414f-b48c-66a4fc06cdef" = true
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"

--- a/exercises/practice/affine-cipher/.meta/tests.toml
+++ b/exercises/practice/affine-cipher/.meta/tests.toml
@@ -1,49 +1,58 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# encode yes
-"2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a" = true
+[2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a]
+description = "encode -> encode yes"
 
-# encode no
-"785bade9-e98b-4d4f-a5b0-087ba3d7de4b" = true
+[785bade9-e98b-4d4f-a5b0-087ba3d7de4b]
+description = "encode -> encode no"
 
-# encode OMG
-"2854851c-48fb-40d8-9bf6-8f192ed25054" = true
+[2854851c-48fb-40d8-9bf6-8f192ed25054]
+description = "encode -> encode OMG"
 
-# encode O M G
-"bc0c1244-b544-49dd-9777-13a770be1bad" = true
+[bc0c1244-b544-49dd-9777-13a770be1bad]
+description = "encode -> encode O M G"
 
-# encode mindblowingly
-"381a1a20-b74a-46ce-9277-3778625c9e27" = true
+[381a1a20-b74a-46ce-9277-3778625c9e27]
+description = "encode -> encode mindblowingly"
 
-# encode numbers
-"6686f4e2-753b-47d4-9715-876fdc59029d" = true
+[6686f4e2-753b-47d4-9715-876fdc59029d]
+description = "encode -> encode numbers"
 
-# encode deep thought
-"ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3" = true
+[ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3]
+description = "encode -> encode deep thought"
 
-# encode all the letters
-"c93a8a4d-426c-42ef-9610-76ded6f7ef57" = true
+[c93a8a4d-426c-42ef-9610-76ded6f7ef57]
+description = "encode -> encode all the letters"
 
-# encode with a not coprime to m
-"0673638a-4375-40bd-871c-fb6a2c28effb" = true
+[0673638a-4375-40bd-871c-fb6a2c28effb]
+description = "encode -> encode with a not coprime to m"
 
-# decode exercism
-"3f0ac7e2-ec0e-4a79-949e-95e414953438" = true
+[3f0ac7e2-ec0e-4a79-949e-95e414953438]
+description = "decode -> decode exercism"
 
-# decode a sentence
-"241ee64d-5a47-4092-a5d7-7939d259e077" = true
+[241ee64d-5a47-4092-a5d7-7939d259e077]
+description = "decode -> decode a sentence"
 
-# decode numbers
-"33fb16a1-765a-496f-907f-12e644837f5e" = true
+[33fb16a1-765a-496f-907f-12e644837f5e]
+description = "decode -> decode numbers"
 
-# decode all the letters
-"20bc9dce-c5ec-4db6-a3f1-845c776bcbf7" = true
+[20bc9dce-c5ec-4db6-a3f1-845c776bcbf7]
+description = "decode -> decode all the letters"
 
-# decode with no spaces in input
-"623e78c0-922d-49c5-8702-227a3e8eaf81" = true
+[623e78c0-922d-49c5-8702-227a3e8eaf81]
+description = "decode -> decode with no spaces in input"
 
-# decode with too many spaces
-"58fd5c2a-1fd9-4563-a80a-71cff200f26f" = true
+[58fd5c2a-1fd9-4563-a80a-71cff200f26f]
+description = "decode -> decode with too many spaces"
 
-# decode with a not coprime to m
-"b004626f-c186-4af9-a3f4-58f74cdb86d5" = true
+[b004626f-c186-4af9-a3f4-58f74cdb86d5]
+description = "decode -> decode with a not coprime to m"

--- a/exercises/practice/all-your-base/.meta/tests.toml
+++ b/exercises/practice/all-your-base/.meta/tests.toml
@@ -1,64 +1,73 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# single bit one to decimal
-"5ce422f9-7a4b-4f44-ad29-49c67cb32d2c" = true
+[5ce422f9-7a4b-4f44-ad29-49c67cb32d2c]
+description = "single bit one to decimal"
 
-# binary to single decimal
-"0cc3fea8-bb79-46ac-a2ab-5a2c93051033" = true
+[0cc3fea8-bb79-46ac-a2ab-5a2c93051033]
+description = "binary to single decimal"
 
-# single decimal to binary
-"f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8" = true
+[f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8]
+description = "single decimal to binary"
 
-# binary to multiple decimal
-"2c45cf54-6da3-4748-9733-5a3c765d925b" = true
+[2c45cf54-6da3-4748-9733-5a3c765d925b]
+description = "binary to multiple decimal"
 
-# decimal to binary
-"65ddb8b4-8899-4fcc-8618-181b2cf0002d" = true
+[65ddb8b4-8899-4fcc-8618-181b2cf0002d]
+description = "decimal to binary"
 
-# trinary to hexadecimal
-"8d418419-02a7-4824-8b7a-352d33c6987e" = true
+[8d418419-02a7-4824-8b7a-352d33c6987e]
+description = "trinary to hexadecimal"
 
-# hexadecimal to trinary
-"d3901c80-8190-41b9-bd86-38d988efa956" = true
+[d3901c80-8190-41b9-bd86-38d988efa956]
+description = "hexadecimal to trinary"
 
-# 15-bit integer
-"5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = true
+[5d42f85e-21ad-41bd-b9be-a3e8e4258bbf]
+description = "15-bit integer"
 
-# empty list
-"d68788f7-66dd-43f8-a543-f15b6d233f83" = true
+[d68788f7-66dd-43f8-a543-f15b6d233f83]
+description = "empty list"
 
-# single zero
-"5e27e8da-5862-4c5f-b2a9-26c0382b6be7" = true
+[5e27e8da-5862-4c5f-b2a9-26c0382b6be7]
+description = "single zero"
 
-# multiple zeros
-"2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2" = true
+[2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2]
+description = "multiple zeros"
 
-# leading zeros
-"3530cd9f-8d6d-43f5-bc6e-b30b1db9629b" = true
+[3530cd9f-8d6d-43f5-bc6e-b30b1db9629b]
+description = "leading zeros"
 
-# input base is one
-"a6b476a1-1901-4f2a-92c4-4d91917ae023" = true
+[a6b476a1-1901-4f2a-92c4-4d91917ae023]
+description = "input base is one"
 
-# input base is zero
-"e21a693a-7a69-450b-b393-27415c26a016" = true
+[e21a693a-7a69-450b-b393-27415c26a016]
+description = "input base is zero"
 
-# input base is negative
-"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = true
+[54a23be5-d99e-41cc-88e0-a650ffe5fcc2]
+description = "input base is negative"
 
-# negative digit
-"9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = true
+[9eccf60c-dcc9-407b-95d8-c37b8be56bb6]
+description = "negative digit"
 
-# invalid positive digit
-"232fa4a5-e761-4939-ba0c-ed046cd0676a" = true
+[232fa4a5-e761-4939-ba0c-ed046cd0676a]
+description = "invalid positive digit"
 
-# output base is one
-"14238f95-45da-41dc-95ce-18f860b30ad3" = true
+[14238f95-45da-41dc-95ce-18f860b30ad3]
+description = "output base is one"
 
-# output base is zero
-"73dac367-da5c-4a37-95fe-c87fad0a4047" = true
+[73dac367-da5c-4a37-95fe-c87fad0a4047]
+description = "output base is zero"
 
-# output base is negative
-"13f81f42-ff53-4e24-89d9-37603a48ebd9" = true
+[13f81f42-ff53-4e24-89d9-37603a48ebd9]
+description = "output base is negative"
 
-# both bases are negative
-"0e6c895d-8a5d-4868-a345-309d094cfe8d" = true
+[0e6c895d-8a5d-4868-a345-309d094cfe8d]
+description = "both bases are negative"

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,43 +1,52 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# encode yes
-"2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = true
+[2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
+description = "encode -> encode yes"
 
-# encode no
-"b4ffe781-ea81-4b74-b268-cc58ba21c739" = true
+[b4ffe781-ea81-4b74-b268-cc58ba21c739]
+description = "encode -> encode no"
 
-# encode OMG
-"10e48927-24ab-4c4d-9d3f-3067724ace00" = true
+[10e48927-24ab-4c4d-9d3f-3067724ace00]
+description = "encode -> encode OMG"
 
-# encode spaces
-"d59b8bc3-509a-4a9a-834c-6f501b98750b" = true
+[d59b8bc3-509a-4a9a-834c-6f501b98750b]
+description = "encode -> encode spaces"
 
-# encode mindblowingly
-"31d44b11-81b7-4a94-8b43-4af6a2449429" = true
+[31d44b11-81b7-4a94-8b43-4af6a2449429]
+description = "encode -> encode mindblowingly"
 
-# encode numbers
-"d503361a-1433-48c0-aae0-d41b5baa33ff" = true
+[d503361a-1433-48c0-aae0-d41b5baa33ff]
+description = "encode -> encode numbers"
 
-# encode deep thought
-"79c8a2d5-0772-42d4-b41b-531d0b5da926" = true
+[79c8a2d5-0772-42d4-b41b-531d0b5da926]
+description = "encode -> encode deep thought"
 
-# encode all the letters
-"9ca13d23-d32a-4967-a1fd-6100b8742bab" = true
+[9ca13d23-d32a-4967-a1fd-6100b8742bab]
+description = "encode -> encode all the letters"
 
-# decode exercism
-"bb50e087-7fdf-48e7-9223-284fe7e69851" = true
+[bb50e087-7fdf-48e7-9223-284fe7e69851]
+description = "decode -> decode exercism"
 
-# decode a sentence
-"ac021097-cd5d-4717-8907-b0814b9e292c" = true
+[ac021097-cd5d-4717-8907-b0814b9e292c]
+description = "decode -> decode a sentence"
 
-# decode numbers
-"18729de3-de74-49b8-b68c-025eaf77f851" = true
+[18729de3-de74-49b8-b68c-025eaf77f851]
+description = "decode -> decode numbers"
 
-# decode all the letters
-"0f30325f-f53b-415d-ad3e-a7a4f63de034" = true
+[0f30325f-f53b-415d-ad3e-a7a4f63de034]
+description = "decode -> decode all the letters"
 
-# decode with too many spaces
-"39640287-30c6-4c8c-9bac-9d613d1a5674" = true
+[39640287-30c6-4c8c-9bac-9d613d1a5674]
+description = "decode -> decode with too many spaces"
 
-# decode with no spaces
-"b34edf13-34c0-49b5-aa21-0768928000d5" = true
+[b34edf13-34c0-49b5-aa21-0768928000d5]
+description = "decode -> decode with no spaces"

--- a/exercises/practice/zebra-puzzle/.meta/tests.toml
+++ b/exercises/practice/zebra-puzzle/.meta/tests.toml
@@ -1,7 +1,16 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# resident who drinks water
-"16efb4e4-8ad7-4d5e-ba96-e5537b66fd42" = true
+[16efb4e4-8ad7-4d5e-ba96-e5537b66fd42]
+description = "resident who drinks water"
 
-# resident who owns zebra
-"084d5b8b-24e2-40e6-b008-c800da8cd257" = true
+[084d5b8b-24e2-40e6-b008-c800da8cd257]
+description = "resident who owns zebra"


### PR DESCRIPTION
Related to #707. 

I'm making my way through the `configlet sync --tests` output. I did a manual check of these five so far, and they appear to have all the tests implemented. Configlet just can't parse their older toml files so these are false positives. Mark as tiny.