### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 The anagrams can be returned in any order.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions Append
 
-## Implementation
+## Track specific instructions
 
 The anagrams can be returned in any order.

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-Since this is your first Kotlin exercise, we've included a detailed TUTORIAL.md
-file that guides you through your solution. Check it out for tips and
-assistance!
+## Implementation
 
+Since this is your first Kotlin exercise, we've included a detailed TUTORIAL.md file that guides you through your solution.
+Check it out for tips and assistance!

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Implementation
+## Track specific instructions
 
 Since this is your first Kotlin exercise, we've included a detailed TUTORIAL.md file that guides you through your solution.
 Check it out for tips and assistance!

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 The tests for this exercise require you to use extensions, a mechanism for adding new functionality to an existing class whose source you do not directly control without having to subclass it.
 To learn more about Kotlin's implementations of extensions, check out the [official documentation](https://kotlinlang.org/docs/reference/extensions.html#extensions).

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,5 +1,9 @@
-# Hints
+# Instructions append
 
-The tests for this exercise require you to use extensions, a mechanism for adding new functionality to an existing class whose source you do not directly control without having to subclass it. To learn more about Kotlin's implementations of extensions, check out the [official documentation](https://kotlinlang.org/docs/reference/extensions.html#extensions).
+## Hints
 
-The `customFoldLeft` and `customFoldRight` methods are "fold" functions, which is a concept well-known in the functional programming world, but less so in the object-oriented one. If you'd like more background information, check out this [fold](https://en.wikipedia.org/wiki/Fold_(higher-order_function)) page.
+The tests for this exercise require you to use extensions, a mechanism for adding new functionality to an existing class whose source you do not directly control without having to subclass it.
+To learn more about Kotlin's implementations of extensions, check out the [official documentation](https://kotlinlang.org/docs/reference/extensions.html#extensions).
+
+The `customFoldLeft` and `customFoldRight` methods are "fold" functions, which is a concept well-known in the functional programming world, but less so in the object-oriented one.
+If you'd like more background information, check out this [fold](https://en.wikipedia.org/wiki/Fold_(higher-order_function)) page.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.